### PR TITLE
Do not count expected income in what a committee has. Add new 'Unreceived' status

### DIFF
--- a/committee/selectcommittee.php
+++ b/committee/selectcommittee.php
@@ -239,7 +239,7 @@ try {
 	$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 	// anyone with approval status in a committee for any amount can view the entire committee
 	$sql = "SELECT SUM(amount) AS income FROM Income
-	WHERE type in ('BOSO', 'Cash', 'SOGA') AND committee = '$committee'
+	WHERE type in ('BOSO', 'Cash', 'SOGA') AND committee = '$committee' AND status = 'Received'
 	AND fiscalyear = '$fiscalyear'";
 
 	foreach ($conn->query($sql) as $row) {
@@ -295,7 +295,7 @@ try {
 	$conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 	// anyone with approval status in a committee for any amount can view the entire committee
 	$sql = "SELECT SUM(amount) AS income FROM Income
-	WHERE type in ('BOSO', 'Cash', 'SOGA') AND committee = '$committee'
+	WHERE type in ('BOSO', 'Cash', 'SOGA') AND committee = '$committee' AND status = 'Received'
 	";
 
 	foreach ($conn->query($sql) as $row) {

--- a/donation/donationprocessing.php
+++ b/donation/donationprocessing.php
@@ -19,6 +19,9 @@ $amount = test_input($_POST["amount"]);
 $item = test_input($_POST["item"]);
 $category = test_input($_POST["category"]);
 $status = test_input($_POST["status"]);
+if($category === "BOSO" && $status === "Received") {
+    $status = "Expected";
+}
 $comments = test_input($_POST["comments"]);
 
 $usr = $_SESSION['user'];
@@ -45,6 +48,6 @@ catch(PDOException $e)
     }
 
 $conn = null;
-header('Location: index.php'); 
+header('Location: index.php');
 
 ?>

--- a/donation/index.php
+++ b/donation/index.php
@@ -71,6 +71,7 @@
     <select id="status" name="status" class="form-control">
       <option value="Expected">Expected</option>
       <option value="Received">Received</option>
+      <option value="Unreceived">Unreceived</option>
     </select>
   </div>
 </div>

--- a/income/index.php
+++ b/income/index.php
@@ -57,19 +57,16 @@
 			$items .= '</td> <td>';
 			$items .= $row['refnumber'];
 			$items .= '</td> <td>';
-			$items .= "<a href='javascript:updateIncome(\"";
-			$items .= $row['incomeid'];
-			$items .= "\", \"";
-
-			if(strcmp($row['status'],'Expected') == 0) {
-				$items .= "Received\")'>";
-				$items .= 'Mark Received';
-			} else {
-				$items .= "Expected\")'>";
-				$items .= 'Mark Expected';
+			if($row['status'] !== "Expected") {
+				$items .= "<a href='javascript:updateIncome(\"" . $row['incomeid'] . "\", \"Expected\")'>Mark Expected</a> ";
 			}
-			$items .= '</a></td>';
-			$items .= '</tr>';
+			if($row['status'] !== "Received") {
+				$items .= "<a href='javascript:updateIncome(\"" . $row['incomeid'] . "\", \"Received\")'>Mark Received</a> ";
+			}
+			if($row['status'] !== "Unreceived") {
+				$items .= "<a href='javascript:updateIncome(\"" . $row['incomeid'] . "\", \"Unreceived\")'>Mark Unreceived</a>";
+			}
+			$items .= '</td> </tr>';
 
 		}
 


### PR DESCRIPTION
From our discussion a few months ago. Several changes:

- New 'Unreceived' category for funding that doesn't arrive
- People cannot enter money as received if it's BOSO type
- 'Expected' income is not counted in a committee's current funds