### PR TITLE
Add a link to open the receipt in a new tab when someone is viewing the purchase

### DIFF
--- a/purchase.php
+++ b/purchase.php
@@ -37,8 +37,8 @@
 		</div>
 	</div>
 
-	
-	
+
+
 	<div class="row">
 		<div class="col-sm-3">
 		</div>
@@ -50,8 +50,8 @@
 		</div>
 	</div>
 
-	
-	
+
+
 	<div class="row">
 		<div class="col-sm-3">
 		</div>
@@ -63,8 +63,8 @@
 		</div>
 	</div>
 
-	
-	
+
+
 	<div class="row">
 		<div class="col-sm-3">
 		</div>
@@ -89,8 +89,8 @@
 		</div>
 	</div>
 
-	
-	
+
+
 	<div class="row">
 		<div class="col-sm-3">
 		</div>
@@ -102,13 +102,21 @@
 		</div>
 	</div>
 
-	<br>	
+	<div class="row">
+		<div class="col-sm-3">
+		</div>
+		<div class="col-sm-4">
+			<p><a href="<?php echo $values['receipt'] ?>">Open receipt in full tab</p>
+		</div>
+	</div>
+
+	<br>
 
 	<div class="row">
 	<div class="col-sm-2">
 	</div>
 	<div class="col-sm-8">
-		<?php 
+		<?php
 			if($values['receipt'] == '') :
 				echo '<h1> <center> There is no receipt for this purchase. </center> </h1>';
 			else :


### PR DESCRIPTION
Previous one could only open a full receipt from the "View Purchases" tab. Now there is a link on the purchase page for viewing a single purchase that opens the receipt in the tab.