### PR TITLE
Enable users to select how they want checks delivered

### DIFF
--- a/api/src/routes/account.js
+++ b/api/src/routes/account.js
@@ -399,6 +399,26 @@ router.get("/:userID/reimbursements", async(req, res, next) => {
 });
 
 /*
+    Get a list of all mailed checks for the user
+*/
+router.get("/:userID/checks", async (req, res, next) => {
+    if (req.context.request_user_id !== req.params.userID) {
+        res.status(404).send("User not found");
+        return next();
+    }
+
+    try {
+        const [results] = await req.context.models.purchase.getChecks(req.params.userID);
+        res.status(200).send(results);
+        return next();
+    } catch (err) {
+        logger.error(err.stack);
+        res.status(500).send("Internal Server Error");
+        return next();
+    }
+});
+
+/*
     Get a list of all committee balances user can view
 */
 router.get("/:userID/balances", async(req, res, next) => {

--- a/api/src/routes/account.js
+++ b/api/src/routes/account.js
@@ -401,7 +401,7 @@ router.get("/:userID/reimbursements", async(req, res, next) => {
 /*
     Get a list of all mailed checks for the user
 */
-router.get("/:userID/checks", async (req, res, next) => {
+router.get("/:userID/checks", async(req, res, next) => {
     if (req.context.request_user_id !== req.params.userID) {
         res.status(404).send("User not found");
         return next();

--- a/api/src/routes/purchase.js
+++ b/api/src/routes/purchase.js
@@ -245,7 +245,7 @@ router.post("/treasurer", async(req, res, next) => {
         const email_to_send_mail = {};
         for (let id of commaIDlist) {
             const [purchase_deets] = await req.context.models.purchase.getFullPurchaseByID(id);
-            if (purchase_deets[0].check_type === 'Mailed') {
+            if (purchase_deets[0].check_type === "Mailed") {
                 if (email_to_send_mail[purchase_deets[0].username] === undefined) {
                     email_to_send_mail[purchase_deets[0].username] = [purchase_deets[0].item];
                 } else {
@@ -303,8 +303,8 @@ router.post("/treasurer", async(req, res, next) => {
                 text += "Your check should have arrived before this email was sent.\n\n";
                 html += "<p>Your check should have arrived before this email was sent.</p>";
             } else {
-                text += `Please check your mailbox over the next few weeks. Make sure to mark the check as received once it arrives.\n\n`;
-                html += `</ul><p>Please check your mailbox over the next few weeks. Make sure to mark the check as received once it arrives.</p>`;
+                text += "Please check your mailbox over the next few weeks. Make sure to mark the check as received once it arrives.\n\n";
+                html += "</ul><p>Please check your mailbox over the next few weeks. Make sure to mark the check as received once it arrives.</p>";
             }
 
             text += "This email was automatically sent by Boiler Books";
@@ -839,7 +839,7 @@ router.post("/:purchaseID/receipt", fileHandler.single("receipt"), async(req, re
 /*
     Mark a check as received
 */
-router.post("/:purchaseID/checks", async (req, res, next) => {
+router.post("/:purchaseID/checks", async(req, res, next) => {
     try {
         const [results] = await req.context.models.purchase.getFullPurchaseByID(req.params.purchaseID);
         if (results.length === 0) {
@@ -851,12 +851,12 @@ router.post("/:purchaseID/checks", async (req, res, next) => {
             return next();
         }
 
-        if (results[0].check_type !== 'Mailed') {
+        if (results[0].check_type !== "Mailed") {
             res.status(400).send("Check was not mailed");
             return next();
         }
 
-        if (results[0].status !== 'Processing Reimbursement') {
+        if (results[0].status !== "Processing Reimbursement") {
             res.status(400).send("Check was not mailed");
             return next();
         }

--- a/config/ieee-money.sql
+++ b/config/ieee-money.sql
@@ -75,6 +75,7 @@ CREATE TABLE `Purchases` (
   `approvedby` varchar(50) DEFAULT NULL,
   `fundsource` enum('BOSO','Cash','SOGA') DEFAULT NULL,
   `comments` varchar(500) NOT NULL,
+  `check_type` enum('Pick-up', 'Mailed') NOT NULL,
   `fiscal_year` int(10) UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 

--- a/ui/src/components/PurchaseNav.vue
+++ b/ui/src/components/PurchaseNav.vue
@@ -4,6 +4,7 @@
     <router-link to="/purchase/approve" class="list-group-item" exact-active-class="active" v-if="auth_state.viewApprove">Approve Purchase</router-link>
     <router-link to="/purchase/complete" class="list-group-item" exact-active-class="active">Complete Purchase</router-link>
     <router-link to="/purchase/reimburse" class="list-group-item" exact-active-class="active" v-if="auth_state.viewTreasurer">Reimburse Purchases</router-link>
+    <router-link to="/purchase/checks" class="list-group-item" exact-active-class="active">Receive Mailed Checks</router-link>
     <router-link to="/purchase/view" class="list-group-item" exact-active-class="active">View My Purchases</router-link>
     <router-link to="/purchase/reimbursements" class="list-group-item" exact-active-class="active" v-if="auth_state.viewTreasurer">View All Purchases</router-link>
     <router-link to="/" class="list-group-item">Boiler Books Home</router-link>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -120,6 +120,10 @@ const routes = [
         component: () => import(/* webpackChunkName: "purchase_reimburse" */ '../views/purchase/PurchaseReimburse.vue'),
       },
       {
+        path: 'checks',
+        component: () => import(/* webpackChunkName: "purchase_checks" */ '../views/purchase/PurchaseChecks.vue'),
+      },
+      {
         path:'view',
         component: () => import(/* webpackChunkName: "purchase_view" */ '../views/purchase/PurchaseView.vue'),
       },

--- a/ui/src/views/DetailView.vue
+++ b/ui/src/views/DetailView.vue
@@ -5,8 +5,11 @@
     <div v-if="dispmsg!==''" class="lead fw-bold my-1 fs-3" v-bind:class="{'text-success':!error,'text-danger':error}">{{dispmsg}}</div>
     <br v-else>
     <p class="lead">Last Modified at <u>{{localDate}}</u></p>
-    <button class="btn btn-primary" v-if="!editPurchase&&auth_state.viewTreasurer&&allowedToEdit" v-on:click="editPurchase=!editPurchase">Update Purchase Details</button>
-    <button class="btn btn-secondary" v-else-if="editPurchase" v-on:click="finishEdit">Finish Purchase Edit</button>
+    <button class="btn btn-primary" v-if="!editPurchase&&auth_state.viewTreasurer&&allowedToEdit" v-on:click="editPurchase=true">Update Purchase Details</button>
+    <div v-else-if="editPurchase">
+      <button class="btn btn-success m-1" v-on:click="finishEdit">Finish Purchase Edit</button>
+      <button class="btn btn-secondary m-1" v-on:click="editPurchase=false">Cancel Purchase Edit</button>
+    </div>
     <br><br>
     <div class="row">
       <!-- This looks misaligned but its actually centered -->
@@ -45,7 +48,7 @@
           <div class="col-md-6 border border-secondary p-3">
             <div class="fs-5">Category:
               <span class="fw-bold" v-if="!editPurchase">{{purchase.category}}</span>
-              <select class="form-select" v-model="category" v-if="editPurchase">
+              <select class="form-select" v-else v-model="category">
                 <option v-for="key in categoryList" v-bind:key="key.category">{{key.category}}</option>
               </select>
             </div>
@@ -66,6 +69,15 @@
             <p class="fs-5">Comments:
               <span class="fw-bold" v-if="!editPurchase">{{purchase.comments}}</span>
               <input class="form-control" v-else v-model="comments">
+            </p>
+          </div>
+          <div class="offset-md-3 col-md-6 border border-secondary p-3">
+            <p class="fs-5">Check Type:
+              <span class="fw-bold" v-if="!editPurchase">{{purchase.check_type}}</span>
+              <select id="checkSelect" v-else class="form-select" v-model="check_type">
+                <option value="Pick-up">Pick-up</option>
+                <option value="Mailed">Mailed</option>
+              </select>
             </p>
           </div>
         </div>
@@ -124,6 +136,7 @@ export default {
       comments: '',
       category: '',
       item: '',
+      check_type: '',
       editPurchase: false,
       categoryList: [],
     }
@@ -155,6 +168,7 @@ export default {
       this.comments = response.response.comments;
       this.category = response.response.category;
       this.cost = response.response.cost;
+      this.check_type = response.response.check_type;
     },
     async finishEdit() {
       this.dispmsg = '';
@@ -162,7 +176,7 @@ export default {
         method: 'put',
         credentials: 'include',
         headers: new Headers({'content-type': 'application/json'}),
-        body: JSON.stringify({reason:this.reason,cost:this.cost,vendor:this.vendor,comments:this.comments,category:this.category}),
+        body: JSON.stringify({reason:this.reason,cost:this.cost,vendor:this.vendor,comments:this.comments,category:this.category,check_type:this.check_type}),
       });
 
       this.error = response.error;

--- a/ui/src/views/purchase/PurchaseChecks.vue
+++ b/ui/src/views/purchase/PurchaseChecks.vue
@@ -1,0 +1,103 @@
+<template>
+  <div>
+    <h3>Receive Mailed Checks</h3>
+    <p class="lead">Below are your pending mailed reimbursement. Mark them once you receive the check.</p>
+    <div v-if="dispmsg!==''" class="lead fw-bold my-1 fs-3" v-bind:class="{'text-success':!error,'text-danger':error}">{{dispmsg}}</div>
+    <br v-else>
+    <!-- As much as I would like, all the fields do not fit here -->
+    <DataTable
+      v-bind:rows="rows"
+      v-bind:row_key="'purchaseID'"
+      v-bind:row_headers="[
+        ['Date','date'],
+        ['Item','item'],
+        ['Vendor','vendor'],
+        ['Committee','committee'],
+        ['Approver','approvedby'],
+        ['Amount','cost'],
+        ['Received?','']]"
+    >
+      <template v-slot:data="purchase">
+        <td>{{purchase.row.date}}</td>
+        <td><router-link v-bind:to="goToItem(purchase.row.purchaseid)" class="link-primary text-decoration-none">{{purchase.row.item}}</router-link></td>
+        <td>{{purchase.row.vendor}}</td>
+        <td>{{purchase.row.committee}}</td>
+        <td>{{purchase.row.approvedby}}</td>
+        <td>${{purchase.row.cost}}</td>
+        <td><button class="btn btn-success" v-on:click="markReceived(purchase.row.purchaseID)">Check Received</button></td>
+      </template>
+    </DataTable>
+  </div>
+</template>
+
+<script>
+/*
+  Copyright 2022 Purdue IEEE and Hadi Ahmed
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import auth_state from '@/state';
+import DataTable from '@/components/DataTable.vue';
+import {fetchWrapperJSON, fetchWrapperTXT} from '@/api_wrapper';
+
+export default {
+  name: 'PurchaseChecks',
+  components: {
+    DataTable,
+  },
+  data() {
+    return {
+      dispmsg: '',
+      error: false,
+      rows: []
+    }
+  },
+  mounted() {
+    this.init();
+  },
+  methods: {
+    goToItem(id) {
+      return `/detail-view?id=${id}`;
+    },
+    async markReceived(purchaseid) {
+      const response = await fetchWrapperTXT(`/api/v2/purchase/${purchaseid}/checks`, {
+        method: 'post',
+        credentials: 'include',
+      });
+
+      this.dispmsg = response.response;
+
+      if (response.error) {
+        this.error = true;
+      } else {
+        this.init();
+      }
+    },
+    async init() {
+      const response = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/checks`, {
+          method: 'get',
+          credentials: 'include',
+      });
+
+      if (response.error) {
+        this.error = true;
+        this.dispmsg = response;
+        return;
+      }
+
+      this.rows = response.response;
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Users can now request a check delivery method when they create the purchase request.

Treasurers can edit the delivery method from the detailed view screen.

Once a mailed check has arrived, the user can mark it as received with changes the status to 'Reimbursed'.