### PR TITLE
Refactor the API to move things out of common_items

### DIFF
--- a/api/src/common_items.js
+++ b/api/src/common_items.js
@@ -38,69 +38,6 @@ const min_fiscal_year_count = 1;
 const max_fiscal_year_count = fiscal_year_list.length;
 // -------------------------------------------------
 
-// ------------ financial committee lut ------------
-// this is the best solution I can come up with
-//  with out a database schema migration. Here is the problem:
-//  the committee column in the database is an enum with some values,
-//  but the name of the committee does not match the enum value.
-//  Further, the name of the committee is not a http safe thing to put in a URL.
-//  Therefore, this is a lookup table of sorts to cross reference these
-//  three different names for THE SAME COMMITEE
-// format = { http-name: [ db enum, committee name ] }
-const committee_lut =
-{
-    "general":["General IEEE", "General IEEE"],
-    "aerial":["Aerial Robotics", "Aerial Robotics"],
-    "csociety":["Computer Society", "Computer Society"],
-    "embs":["EMBS", "EMBS"],
-    "mtt-s":["MTT-S", "MTT-S"],
-    "racing":["Racing", "Racing"],
-    "rov":["ROV", "ROV"],
-    "soga":["SOGA", "SOGA"],
-};
-// mini-LUT for db enum : committee name
-const committee_name_swap =
-{
-    "General IEEE":"General IEEE",
-    "Aerial Robotics":"Aerial Robotics",
-    "Computer Society":"Computer Society",
-    "EMBS":"EMBS",
-    "MTT-S":"MTT-S",
-    "Racing":"Racing",
-    "ROV":"ROV",
-    "SOGA":"SOGA",
-};
-// mini-LUT for db enum : api name
-const committee_name_api =
-{
-    "General IEEE":"general",
-    "Aerial Robotics":"aerial",
-    "Computer Society":"csociety",
-    "EMBS":"embs",
-    "MTT-S":"mtt-s",
-    "Racing":"racing",
-    "ROV":"rov",
-    "SOGA":"soga",
-};
-// -------------------------------------------------
-
-// ------------- dues committee lut ----------------
-// List of all committees a member can be part of
-const dues_committees =
-[
-    "Aerial Robotics",
-    "Computer Society",
-    "EMBS",
-    "Growth & Engagement",
-    "MTT-S",
-    "Learning",
-    "Racing",
-    "ROV",
-    "Social",
-    "Software Saturdays"
-];
-// -------------------------------------------------
-
 // ----------------- dues amount -------------------
 // Current annual local dues
 
@@ -141,10 +78,6 @@ export {
     fiscal_year_lut,
     min_fiscal_year_count,
     max_fiscal_year_count,
-    committee_lut,
-    committee_name_swap,
-    committee_name_api,
-    dues_committees,
     dues_amount,
     ACCESS_LEVEL,
     cleanUTF8,

--- a/api/src/common_items.js
+++ b/api/src/common_items.js
@@ -16,8 +16,6 @@
 
 // variables, functions, enums, etc. that are used elsewhere in the code
 
-import { logger } from "./utils/logging.js";
-
 // -------------- fiscal year globals -------------
 
 /** CHANGE BELOW ANNUALLY **/
@@ -123,46 +121,6 @@ const ACCESS_LEVEL = Object.freeze({
 });
 // -------------------------------------------------
 
-// ----------------- Logging -----------------------
-
-// -------------------------------------------------
-
-// ------------------ SMTP mailer ------------------
-import nodemailer from "nodemailer";
-const mailer = nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: process.env.SMTP_PORT,
-    secure: false,
-    ignoreTLS: true,
-},{
-    from: "Boiler Books <boilerbooks@purdueieee.org>",
-});
-
-// Backoff smtp startup check
-let try_count = 0;
-let smtp_good = false;
-function smtp_startup() {
-    mailer.verify((err) => {
-        if (!err) {
-            logger.info("SMTP connection verified");
-            smtp_good = true;
-            return;
-        }
-        logger.error(`SMTP connection fail ${try_count}: ${err.message}`);
-        try_count += 1;
-        if (try_count >= 5) {
-            logger.error("SMTP connection failed to verify");
-            process.exit(1);
-        }
-        setTimeout(smtp_startup, try_count * 1000); // Retry the startup, backoff longer each time
-    });
-}
-function smtp_check() {
-    return smtp_good;
-}
-smtp_startup();
-// -------------------------------------------------
-
 // ---------------- utf-8 -> ascii ----------------
 function cleanUTF8(input) {
     let clean = "";
@@ -189,7 +147,5 @@ export {
     dues_committees,
     dues_amount,
     ACCESS_LEVEL,
-    mailer,
-    smtp_check,
     cleanUTF8,
 };

--- a/api/src/common_items.js
+++ b/api/src/common_items.js
@@ -16,49 +16,7 @@
 
 // variables, functions, enums, etc. that are used elsewhere in the code
 
-// ---------------- un/escape functions ---------------
-// Escaping is not necessary with our usage of Prepared Statements
-// These are left here if needed but they are not exported or used
-// -> Only concern is if the API user does not sanitize the
-// ->   possibly valid HTML in the responses.
-// ->   Vue does this an thereforore our front-end is safe.
-
-// (NOT USED)
-function clean_input_all(string) {
-    // ' " \ / < > ` &
-    string = string.replaceAll(/['"\\/<>&`]/ig, "");
-    string = string.trim();
-    return string;
-}
-
-// (NOT USED)
-function clean_input_keepslash(string) {
-    // ' " \ < > ` &
-    string = string.replaceAll(/['"\\<>&`]/ig, "");
-    string = string.trim();
-    return string;
-}
-
-// (NOT USED)
-function clean_input_encodeurl(string) {
-    //string = string.replaceAll(/[']/ig, '%27');
-    string = encodeURIComponent(string);
-    return string;
-}
-
-// (NOT USED)
-function unescape_object(obj) {
-    for (let key in obj) {
-        // javascript is a perfect language with no flaws
-        if (Object.prototype.hasOwnProperty.call(obj, key) && obj[key] && typeof(obj[key]) === "string") {
-            //obj[key] = obj[key].replaceAll(/[%27]/ig, "'");
-            obj[key] = decodeURIComponent(obj[key]);
-        }
-    }
-
-    return obj;
-}
-// -------------------------------------------------
+import { logger } from "./utils/logging.js";
 
 // -------------- fiscal year globals -------------
 
@@ -166,38 +124,7 @@ const ACCESS_LEVEL = Object.freeze({
 // -------------------------------------------------
 
 // ----------------- Logging -----------------------
-import winston from "winston";
-import "winston-daily-rotate-file";
-const transport = new winston.transports.DailyRotateFile({
-    filename: "boilerbooks-%DATE%.log",
-    datePattern:"YYYY-MM-DD",
-    zippedArchive: true,
-    dirname: "/var/log/boilerbooks/",
-    maxSize: "20m",
-    maxFiles: 10,
-});
-const format = winston.format.printf((log) => {
-    return `${log.timestamp} [${log.level}]: ${log.message}`;
-});
-const logger = winston.createLogger({
-    transports: [
-        transport
-    ],
-    level: "info",
-    format: winston.format.combine(
-        winston.format.timestamp(),
-        winston.format.splat(),
-        format
-    ),
-});
-logger.add(new winston.transports.Console({
-    format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.timestamp(),
-        winston.format.splat(),
-        format
-    ),
-}));
+
 // -------------------------------------------------
 
 // ------------------ SMTP mailer ------------------
@@ -263,7 +190,6 @@ export {
     dues_amount,
     ACCESS_LEVEL,
     mailer,
-    logger,
     smtp_check,
     cleanUTF8,
 };

--- a/api/src/controllers/oidc.js
+++ b/api/src/controllers/oidc.js
@@ -16,7 +16,8 @@
 
 import { Issuer, generators } from "openid-client";
 
-import { logger, ACCESS_LEVEL } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import Models from "../models/index.js";
 
 let oidcIssuer;

--- a/api/src/db_loaded_items.js
+++ b/api/src/db_loaded_items.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { logger } from "./common_items.js";
+import { logger } from "./utils/logging.js";
 import { db_conn, db_check } from "./models/index.js";
 
 let committee_display_to_id;

--- a/api/src/db_loaded_items.js
+++ b/api/src/db_loaded_items.js
@@ -15,7 +15,7 @@
 */
 
 import { logger } from "./utils/logging.js";
-import { db_conn, db_check } from "./models/index.js";
+import { db_conn, db_check } from "./utils/db.js";
 
 let committee_display_to_id;
 let committee_id_to_display;

--- a/api/src/middleware/checkAPI.js
+++ b/api/src/middleware/checkAPI.js
@@ -15,7 +15,7 @@
 */
 
 import Models from "../models/index.js";
-import { logger } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 
 async function checkAPI(req, res, next) {
     // If we are attempting to go to the /, /login, or /oidc endpoints, don't authenticate

--- a/api/src/middleware/logging.js
+++ b/api/src/middleware/logging.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { logger } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 
 async function apiLogger(req, res, next) {
     // Log every route and it's result

--- a/api/src/models/access.js
+++ b/api/src/models/access.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { ACCESS_LEVEL } from "../common_items.js";
 
 async function checkApprovalExists(id, committee, checkTreasurer=false) {

--- a/api/src/models/account.js
+++ b/api/src/models/account.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { ACCESS_LEVEL } from "../common_items.js";
 import { v4 as uuidv4} from "uuid";
 

--- a/api/src/models/budgets.js
+++ b/api/src/models/budgets.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 
 async function clearBudget(comm, year) {
     return db_conn.promise().execute(

--- a/api/src/models/committee.js
+++ b/api/src/models/committee.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { max_fiscal_year_count } from "../common_items.js";
 
 async function getCommitteeCategories(comm, year=max_fiscal_year_count) {

--- a/api/src/models/dues.js
+++ b/api/src/models/dues.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { max_fiscal_year_count } from "../common_items.js";
 
 async function createNewMember(dues) {

--- a/api/src/models/income.js
+++ b/api/src/models/income.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { max_fiscal_year_count } from "../common_items.js";
 
 async function createNewDonation(donation) {

--- a/api/src/models/index.js
+++ b/api/src/models/index.js
@@ -23,7 +23,7 @@ import budgets from "./budgets.js";
 import dues from "./dues.js";
 import search from "./search.js";
 
-import { logger } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 
 import mysql2 from "mysql2";
 

--- a/api/src/models/index.js
+++ b/api/src/models/index.js
@@ -23,51 +23,6 @@ import budgets from "./budgets.js";
 import dues from "./dues.js";
 import search from "./search.js";
 
-import { logger } from "../utils/logging.js";
-
-import mysql2 from "mysql2";
-
-// Using a pool allows connections to be remade
-//   Normally, MySQL will kill a connection if it was not
-//   used recently. Pooling them should remove that overhead
-//   check from our code and move it into the library.
-const db_conn = mysql2.createPool({
-    host: process.env.DB_HOST,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASS,
-    database: process.env.DB_DATABASE,
-    waitForConnections: true,
-    connectionLimit: 10,
-    queueLimit: 0,
-    charset: "utf8mb4",
-    decimalNumbers: true,
-});
-
-// Backoff pool startup check
-let try_count = 0;
-let db_good = false;
-function db_startup() {
-    db_conn.getConnection((err, conn) => {
-        if (!err) {
-            logger.info("MySQL connection pool started");
-            db_conn.releaseConnection(conn);
-            db_good = true;
-            return;
-        }
-        logger.error(`MySQL connection pool fail ${try_count}: ${err.message}`);
-        try_count += 1;
-        if (try_count >= 5) {
-            logger.error("MySQL connection pool failed to start");
-            process.exit(1);
-        }
-        setTimeout(db_startup, try_count * 1000); // Retry the startup, backoff longer each time
-    });
-}
-function db_check() {
-    return db_good;
-}
-db_startup();
-
 export default {
     account,
     purchase,
@@ -78,5 +33,3 @@ export default {
     dues,
     search,
 };
-
-export { db_conn, db_check, };

--- a/api/src/models/purchase.js
+++ b/api/src/models/purchase.js
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 import { ACCESS_LEVEL, max_fiscal_year_count } from "../common_items.js";
 
 async function getFullPurchaseByID(id) {

--- a/api/src/models/search.js
+++ b/api/src/models/search.js
@@ -15,7 +15,7 @@
 */
 
 import { ACCESS_LEVEL } from "../common_items.js";
-import { db_conn } from "./index.js";
+import { db_conn } from "../utils/db.js";
 
 async function search(params, id) {
     // These lines seem useless, but they are very important!

--- a/api/src/routes/access.js
+++ b/api/src/routes/access.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { ACCESS_LEVEL, logger } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/account.js
+++ b/api/src/routes/account.js
@@ -17,8 +17,9 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { mailer, ACCESS_LEVEL } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
 import { logger } from "../utils/logging.js";
+import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 import bcrypt from "bcrypt";

--- a/api/src/routes/account.js
+++ b/api/src/routes/account.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { logger, mailer, ACCESS_LEVEL } from "../common_items.js";
+import { mailer, ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 import bcrypt from "bcrypt";

--- a/api/src/routes/budgets.js
+++ b/api/src/routes/budgets.js
@@ -17,8 +17,9 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { fiscal_year_list, ACCESS_LEVEL, max_fiscal_year_count, mailer, current_fiscal_year } from "../common_items.js";
+import { fiscal_year_list, ACCESS_LEVEL, max_fiscal_year_count, current_fiscal_year } from "../common_items.js";
 import { logger } from "../utils/logging.js";
+import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/budgets.js
+++ b/api/src/routes/budgets.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { fiscal_year_list, ACCESS_LEVEL, logger, max_fiscal_year_count, mailer, current_fiscal_year } from "../common_items.js";
+import { fiscal_year_list, ACCESS_LEVEL, max_fiscal_year_count, mailer, current_fiscal_year } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { fiscal_year_list, current_fiscal_year, logger, ACCESS_LEVEL, fiscal_year_lut } from "../common_items.js";
+import { fiscal_year_list, current_fiscal_year, ACCESS_LEVEL, fiscal_year_lut } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/dues.js
+++ b/api/src/routes/dues.js
@@ -18,7 +18,8 @@ import { Router } from "express";
 import crypto from "crypto";
 
 import Models from "../models/index.js";
-import { ACCESS_LEVEL, current_fiscal_year, dues_amount, fiscal_year_list, fiscal_year_lut, logger, max_fiscal_year_count } from "../common_items.js";
+import { ACCESS_LEVEL, current_fiscal_year, dues_amount, fiscal_year_list, fiscal_year_lut, max_fiscal_year_count } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { dues_committees } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/income.js
+++ b/api/src/routes/income.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { ACCESS_LEVEL, logger } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 const router = Router();

--- a/api/src/routes/login.js
+++ b/api/src/routes/login.js
@@ -19,8 +19,9 @@ import crypto from "crypto";
 import bcrypt from "bcrypt";
 
 import Models from "../models/index.js";
-import { mailer, ACCESS_LEVEL } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
 import { logger } from "../utils/logging.js";
+import { mailer } from "../utils/mailer.js";
 
 const router = Router();
 const bcrypt_rounds = 10;

--- a/api/src/routes/login.js
+++ b/api/src/routes/login.js
@@ -19,7 +19,8 @@ import crypto from "crypto";
 import bcrypt from "bcrypt";
 
 import Models from "../models/index.js";
-import { mailer, logger, ACCESS_LEVEL } from "../common_items.js";
+import { mailer, ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 
 const router = Router();
 const bcrypt_rounds = 10;

--- a/api/src/routes/purchase.js
+++ b/api/src/routes/purchase.js
@@ -20,7 +20,8 @@ import * as fs from "fs/promises";
 import jimp from "jimp";
 
 import Models from "../models/index.js";
-import { mailer, logger, ACCESS_LEVEL, cleanUTF8 } from "../common_items.js";
+import { mailer, ACCESS_LEVEL, cleanUTF8 } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 // filter uploaded files based on type

--- a/api/src/routes/purchase.js
+++ b/api/src/routes/purchase.js
@@ -20,8 +20,9 @@ import * as fs from "fs/promises";
 import jimp from "jimp";
 
 import Models from "../models/index.js";
-import { mailer, ACCESS_LEVEL, cleanUTF8 } from "../common_items.js";
+import { ACCESS_LEVEL, cleanUTF8 } from "../common_items.js";
 import { logger } from "../utils/logging.js";
+import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../db_loaded_items.js";
 
 // filter uploaded files based on type

--- a/api/src/routes/receipt.js
+++ b/api/src/routes/receipt.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { ACCESS_LEVEL, logger } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { logger } from "../utils/logging.js";
 
 const router = Router();
 

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -26,7 +26,7 @@ import rateLimit from "express-rate-limit";
 // Import files
 import app from "./app.js";
 import { db_conn, db_check } from "./models/index.js";
-import { smtp_check } from "./common_items.js";
+import { smtp_check } from "./utils/mailer.js";
 import { logger } from "./utils/logging.js";
 import { loader_check } from "./db_loaded_items.js";
 import checkAPI from "./middleware/checkAPI.js";

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -25,10 +25,10 @@ import rateLimit from "express-rate-limit";
 
 // Import files
 import app from "./app.js";
-import { db_conn, db_check } from "./models/index.js";
+import { db_conn, db_check } from "./utils/db.js";
 import { smtp_check } from "./utils/mailer.js";
-import { logger } from "./utils/logging.js";
 import { loader_check } from "./db_loaded_items.js";
+import { logger } from "./utils/logging.js";
 import checkAPI from "./middleware/checkAPI.js";
 import apiLogger from "./middleware/logging.js";
 import { oidc_check } from "./controllers/oidc.js";

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -26,7 +26,8 @@ import rateLimit from "express-rate-limit";
 // Import files
 import app from "./app.js";
 import { db_conn, db_check } from "./models/index.js";
-import { logger, smtp_check } from "./common_items.js";
+import { smtp_check } from "./common_items.js";
+import { logger } from "./utils/logging.js";
 import { loader_check } from "./db_loaded_items.js";
 import checkAPI from "./middleware/checkAPI.js";
 import apiLogger from "./middleware/logging.js";

--- a/api/src/utils/db.js
+++ b/api/src/utils/db.js
@@ -1,0 +1,65 @@
+/*
+   Copyright 2022 Purdue IEEE and Hadi Ahmed
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import { logger } from "../utils/logging.js";
+
+import mysql2 from "mysql2";
+
+// Using a pool allows connections to be remade
+//   Normally, MySQL will kill a connection if it was not
+//   used recently. Pooling them should remove that overhead
+//   check from our code and move it into the library.
+const db_conn = mysql2.createPool({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_DATABASE,
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0,
+    charset: "utf8mb4",
+    decimalNumbers: true,
+});
+
+// Backoff pool startup check
+let try_count = 0;
+let db_good = false;
+function db_startup() {
+    db_conn.getConnection((err, conn) => {
+        if (!err) {
+            logger.info("MySQL connection pool started");
+            db_conn.releaseConnection(conn);
+            db_good = true;
+            return;
+        }
+        logger.error(`MySQL connection pool fail ${try_count}: ${err.message}`);
+        try_count += 1;
+        if (try_count >= 5) {
+            logger.error("MySQL connection pool failed to start");
+            process.exit(1);
+        }
+        setTimeout(db_startup, try_count * 1000); // Retry the startup, backoff longer each time
+    });
+}
+function db_check() {
+    return db_good;
+}
+db_startup();
+
+export {
+    db_conn,
+    db_check,
+};

--- a/api/src/utils/logging.js
+++ b/api/src/utils/logging.js
@@ -1,0 +1,52 @@
+/*
+   Copyright 2022 Purdue IEEE and Hadi Ahmed
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import winston from "winston";
+import "winston-daily-rotate-file";
+const transport = new winston.transports.DailyRotateFile({
+    filename: "boilerbooks-%DATE%.log",
+    datePattern:"YYYY-MM-DD",
+    zippedArchive: true,
+    dirname: "/var/log/boilerbooks/",
+    maxSize: "20m",
+    maxFiles: 10,
+});
+const format = winston.format.printf((log) => {
+    return `${log.timestamp} [${log.level}]: ${log.message}`;
+});
+const logger = winston.createLogger({
+    transports: [
+        transport
+    ],
+    level: "info",
+    format: winston.format.combine(
+        winston.format.timestamp(),
+        winston.format.splat(),
+        format
+    ),
+});
+logger.add(new winston.transports.Console({
+    format: winston.format.combine(
+        winston.format.colorize(),
+        winston.format.timestamp(),
+        winston.format.splat(),
+        format
+    ),
+}));
+
+export {
+    logger,
+};

--- a/api/src/utils/mailer.js
+++ b/api/src/utils/mailer.js
@@ -1,0 +1,56 @@
+/*
+   Copyright 2022 Purdue IEEE and Hadi Ahmed
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import nodemailer from "nodemailer";
+import { logger } from "./logging.js";
+
+const mailer = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT,
+    secure: false,
+    ignoreTLS: true,
+},{
+    from: "Boiler Books <boilerbooks@purdueieee.org>",
+});
+
+// Backoff smtp startup check
+let try_count = 0;
+let smtp_good = false;
+function smtp_startup() {
+    mailer.verify((err) => {
+        if (!err) {
+            logger.info("SMTP connection verified");
+            smtp_good = true;
+            return;
+        }
+        logger.error(`SMTP connection fail ${try_count}: ${err.message}`);
+        try_count += 1;
+        if (try_count >= 5) {
+            logger.error("SMTP connection failed to verify");
+            process.exit(1);
+        }
+        setTimeout(smtp_startup, try_count * 1000); // Retry the startup, backoff longer each time
+    });
+}
+function smtp_check() {
+    return smtp_good;
+}
+smtp_startup();
+
+export {
+    mailer,
+    smtp_check,
+};


### PR DESCRIPTION
Split things into a separate `utils/` folder instead of interlaced into the API files.

Fiscal year stuff was kept together until it could be moved to a DB loaded value.