### PR TITLE
Implemented Read-Only Committee Statuses

### DIFF
--- a/api/src/models/committee.js
+++ b/api/src/models/committee.js
@@ -131,6 +131,13 @@ async function getCommitteeBudgetSummary(comm, year, insgc) {
     );
 }
 
+async function isCommitteeValidForTransactions(comm) {
+    return db_conn.promise().execute(
+        "SELECT 1 FROM committees WHERE committee_id = ? AND bank_status = 'Active'",
+        [comm]
+    );
+}
+
 export default {
     getCommitteeCategories,
     getCommitteeBalance,
@@ -142,4 +149,5 @@ export default {
     getCommitteeIncome,
     getCommitteeBudgetSummary,
     getCommitteePurchasesByDates,
+    isCommitteeValidForTransactions,
 };

--- a/api/src/routes/access.js
+++ b/api/src/routes/access.js
@@ -19,7 +19,7 @@ import { Router } from "express";
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
 import { logger } from "../utils/logging.js";
-import { committee_id_to_display } from "../utils/committees.js";
+import { committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 const router = Router();
 
@@ -56,7 +56,7 @@ router.get("/officers", async(req, res, next) => {
             return next();
         }
         const [results_1] = await Models.access.getApprovals(ACCESS_LEVEL.officer);
-        results_1.forEach((elm) => (elm.committee = committee_id_to_display[elm.committee]));
+        results_1.forEach((elm) => (elm.committee = committee_id_to_display_readonly_included[elm.committee]));
         res.status(200).send(results_1);
         return next();
     } catch (err) {
@@ -78,7 +78,7 @@ router.get("/internals", async(req, res, next) => {
             return next();
         }
         const [results_1] = await Models.access.getApprovals(ACCESS_LEVEL.internal_leader);
-        results_1.forEach((elm) => (elm.committee = committee_id_to_display[elm.committee]));
+        results_1.forEach((elm) => (elm.committee = committee_id_to_display_readonly_included[elm.committee]));
         res.status(200).send(results_1);
         return next();
     } catch (err) {
@@ -130,9 +130,9 @@ router.post("/treasurers", async(req, res, next) => {
             category: "*",
             level: ACCESS_LEVEL.treasurer,
         };
-        for (let committee in committee_id_to_display) {
+        for (let committee in committee_id_to_display_readonly_included) {
             approval.committee = committee;
-            if (committee_id_to_display[committee] === "General IEEE") {
+            if (committee_id_to_display_readonly_included[committee] === "General IEEE") {
                 approval.amount = 1000000; // if they need more than this we have a problem
             }
             await Models.access.addApproval(approval);
@@ -163,7 +163,7 @@ router.post("/officers", async(req, res, next) => {
         return next();
     }
 
-    if (committee_id_to_display[req.body.committee] === undefined) {
+    if (committee_id_to_display_readonly_included[req.body.committee] === undefined) {
         res.status(400).send("Committee must be proper value");
         return next();
     }

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -19,7 +19,7 @@ import { Router } from "express";
 import Models from "../models/index.js";
 import { fiscal_year_list, current_fiscal_year, ACCESS_LEVEL, fiscal_year_lut } from "../common_items.js";
 import { logger } from "../utils/logging.js";
-import { committee_id_to_display } from "../utils/committees.js";
+import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 const router = Router();
 
@@ -28,7 +28,11 @@ const router = Router();
 */
 router.get("/", (req, res, next) => {
     // literally just gets a list of committees
-    res.status(200).send(committee_id_to_display);
+    if (req.query.readonly === "yes") {
+        res.status(200).send(committee_id_to_display_readonly_included);
+    } else {
+        res.status(200).send(committee_id_to_display);
+    }
     return next();
 });
 
@@ -37,7 +41,7 @@ router.get("/", (req, res, next) => {
 */
 router.get("/:commID/categories/:year?", async(req, res, next) => {
     // commKey must be one of the above values, that is in the DB
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -68,7 +72,7 @@ router.get("/:commID/categories/:year?", async(req, res, next) => {
     Get total committee balance
 */
 router.get("/:commID/balance", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -100,7 +104,7 @@ router.get("/:commID/balance", async(req, res, next) => {
     Get total committee credit level
 */
 router.get("/:commID/credit", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -132,7 +136,7 @@ router.get("/:commID/credit", async(req, res, next) => {
     Get committee budget for a year
 */
 router.get("/:commID/budget/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -177,7 +181,7 @@ router.get("/:commID/budget/:year?", async(req, res, next) => {
     Get total expenses for a committee for a year
 */
 router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -222,7 +226,7 @@ router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
     Get total income for a committee for a year
 */
 router.get("/:commID/incometotal/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -267,7 +271,7 @@ router.get("/:commID/incometotal/:year?", async(req, res, next) => {
     Get all purchases for a committee for a year
 */
 router.get("/:commID/purchases/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -308,7 +312,7 @@ router.get("/:commID/purchases/:year?", async(req, res, next) => {
     Get all income for a committee for a year
 */
 router.get("/:commID/income/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -349,7 +353,7 @@ router.get("/:commID/income/:year?", async(req, res, next) => {
     Get financial summary for a committee for a year
 */
 router.get("/:commID/summary/:year?", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -399,7 +403,7 @@ function cleanCSVEntry(text) {
     Get a CSV file of all purchases for a given year
 */
 router.get("/:commID/csv", async(req, res, next) => {
-    if (!(req.params.commID in committee_id_to_display)) {
+    if (!(req.params.commID in committee_id_to_display_readonly_included)) {
         res.status(404).send("Invalid committee value");
         return next();
     }
@@ -447,7 +451,7 @@ router.get("/:commID/csv", async(req, res, next) => {
             csvString += `"${purchase.purchaseid}","${purchase.date}",${cleanCSVEntry(purchase.pby)},${cleanCSVEntry(purchase.item)},${cleanCSVEntry(purchase.vendor)},${purchase.cost},${cleanCSVEntry(purchase.purchasereason)},${cleanCSVEntry(purchase.comments)}\n`;
         }
 
-        res.status(200).attachment(`${committee_id_to_display[req.params.commID].split(" ").join("_")}_${req.query.start}_${req.query.end}.csv`).send(csvString);
+        res.status(200).attachment(`${committee_id_to_display_readonly_included[req.params.commID].split(" ").join("_")}_${req.query.start}_${req.query.end}.csv`).send(csvString);
         return next();
     } catch (err) {
         logger.error(err.stack);

--- a/api/src/routes/infra.js
+++ b/api/src/routes/infra.js
@@ -22,7 +22,7 @@ import loader from "../utils/committees.js";
 
 const router = Router();
 
-const bank_statuses = ["Active", "Inactive"];
+const bank_statuses = ["Active", "Inactive", "Read-Only"];
 const dues_statuses = ["Active", "Inactive"];
 
 router.get("/committees", async(req, res, next) => {

--- a/api/src/routes/search.js
+++ b/api/src/routes/search.js
@@ -16,7 +16,7 @@
 
 import { Router } from "express";
 import { fiscal_year_lut } from "../common_items.js";
-import { committee_id_to_display } from "../utils/committees.js";
+import { committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 import Models from "../models/index.js";
 
@@ -26,7 +26,7 @@ const router = Router();
     Performs an advanced search
 */
 router.post("/", async(req, res, next) => {
-    if ((req.body.committee !== "any") && (committee_id_to_display[req.body.committee] === undefined)) {
+    if ((req.body.committee !== "any") && (committee_id_to_display_readonly_included[req.body.committee] === undefined)) {
         res.status(400).send("Improper committee value");
         return next();
     }
@@ -39,7 +39,7 @@ router.post("/", async(req, res, next) => {
     req.body.fiscalyear = fiscal_year_lut[req.body.fiscalyear] !== undefined ? fiscal_year_lut[req.body.fiscalyear] : "any";
 
     const [results] = await Models.search.search(req.body, req.context.request_user_id);
-    results.forEach((elm) => (elm.committee = committee_id_to_display[elm.committee]));
+    results.forEach((elm) => (elm.committee = committee_id_to_display_readonly_included[elm.committee]));
 
     res.status(201).send(results);
     return next();

--- a/api/src/utils/committees.js
+++ b/api/src/utils/committees.js
@@ -17,8 +17,8 @@
 import { logger } from "./logging.js";
 import { db_conn } from "./db.js";
 
-let committee_display_to_id;
 let committee_id_to_display;
+let committee_id_to_display_readonly_included;
 let dues_committees;
 
 async function performLoad() {
@@ -28,15 +28,15 @@ async function performLoad() {
             []
         );
 
-        committee_display_to_id = results.reduce((out, elm) => {
+        committee_id_to_display = results.reduce((out, elm) => {
             if (elm.bank_status === "Active") {
-                out[elm.display_name] = elm.committee_id;
+                out[elm.committee_id] = elm.display_name;
             }
             return out;
         }, {});
 
-        committee_id_to_display = results.reduce((out, elm) => {
-            if (elm.bank_status === "Active") {
+        committee_id_to_display_readonly_included = results.reduce((out, elm) => {
+            if (elm.bank_status === "Active" || elm.bank_status === "Read-Only") {
                 out[elm.committee_id] = elm.display_name;
             }
             return out;
@@ -79,8 +79,8 @@ async function update() {
 
 // Specific exports
 export {
-    committee_display_to_id,
     committee_id_to_display,
+    committee_id_to_display_readonly_included,
     dues_committees,
 };
 

--- a/config/ieee-money.sql
+++ b/config/ieee-money.sql
@@ -31,7 +31,7 @@ CREATE TABLE `committees` (
   `committee_id` int NOT NULL,
   `display_name` varchar(20) NOT NULL,
   `api_name` varchar(20) NOT NULL,
-  `bank_status` enum('Active', 'Inactive') NOT NULL,
+  `bank_status` enum('Active', 'Inactive', 'Read-Only') NOT NULL,
   `dues_status` enum('Active', 'Inactive') NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET utf8mb4;
 

--- a/ui/src/views/access/AccessInternal.vue
+++ b/ui/src/views/access/AccessInternal.vue
@@ -93,7 +93,7 @@ export default {
   },
   async mounted() {
     this.init();
-    const response = await fetchWrapperJSON(`/api/v2/committee`, {
+    const response = await fetchWrapperJSON(`/api/v2/committee?readonly=yes`, {
       method: 'get',
     });
 

--- a/ui/src/views/access/AccessOfficers.vue
+++ b/ui/src/views/access/AccessOfficers.vue
@@ -83,7 +83,7 @@ export default {
   },
   async mounted() {
     this.init();
-    const response = await fetchWrapperJSON(`/api/v2/committee`, {
+    const response = await fetchWrapperJSON(`/api/v2/committee?readonly=yes`, {
       method: 'get',
     });
 

--- a/ui/src/views/access/AccessTreasurers.vue
+++ b/ui/src/views/access/AccessTreasurers.vue
@@ -75,7 +75,7 @@ export default {
   },
   methods: {
     async init() {
-      const response = await fetchWrapperJSON(`/api/v2/access/treasurers`, {
+      const response = await fetchWrapperJSON(`/api/v2/access/treasurers?readonly=yes`, {
         method: 'get',
       });
 

--- a/ui/src/views/financials/FinancialsCommittee.vue
+++ b/ui/src/views/financials/FinancialsCommittee.vue
@@ -164,7 +164,7 @@ export default {
     }
   },
   async mounted() {
-    const committeeList = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees`, {
+    const committeeList = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees?readonly=yes`, {
       method: 'get',
     });
 

--- a/ui/src/views/financials/FinancialsExport.vue
+++ b/ui/src/views/financials/FinancialsExport.vue
@@ -60,7 +60,7 @@ export default {
     }
   },
   async mounted() {
-    const response = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees`, {
+    const response = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees?readonly=yes`, {
       method: 'get',
     });
 

--- a/ui/src/views/financials/FinancialsSearch.vue
+++ b/ui/src/views/financials/FinancialsSearch.vue
@@ -156,7 +156,7 @@ export default {
     }
   },
   async mounted() {
-    const committeeList = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees`, {
+    const committeeList = await fetchWrapperJSON(`/api/v2/account/${auth_state.state.uname}/committees?readonly=yes`, {
       method: 'get',
     });
 

--- a/ui/src/views/infra/InfraCommittees.vue
+++ b/ui/src/views/infra/InfraCommittees.vue
@@ -62,6 +62,7 @@
         <select v-else v-model="committeeListEdit[idx].bank_status" class="form-select">
           <option>Active</option>
           <option>Inactive</option>
+          <option>Read-Only</option>
         </select>
       </div>
       <div class="col-md-2">
@@ -92,6 +93,7 @@
         <select id="dues-input-new" v-model="new_committee.bank_status" class="form-select">
           <option>Active</option>
           <option>Inactive</option>
+          <option>Read-Only</option>
         </select>
       </div>
       <div class="col-md-2">


### PR DESCRIPTION
Read-Only committees are a status that allows the purchase and income history of a committee to remain, while disallowing any non-complete purchases or new income from being created.

This primarily exists to handle former committees or allow committees to toggle their visibility.

Closes #198