### PR TITLE
Move fiscal year updates to the UI

### DIFF
--- a/api/src/common_items.js
+++ b/api/src/common_items.js
@@ -16,28 +16,6 @@
 
 // variables, functions, enums, etc. that are used elsewhere in the code
 
-// -------------- fiscal year globals -------------
-
-/** CHANGE BELOW ANNUALLY **/
-const current_fiscal_year = "2022-2023";
-/** CHANGE ABOVE ANNUALLY **/
-
-const first_fiscal_year = "2015-2016";
-const yearStart = parseInt(first_fiscal_year.substring(0,4));
-const yearEnd = parseInt(current_fiscal_year.substring(0,4));
-const fiscal_year_list = [];
-for (let year = yearEnd; year >= yearStart; year--) {
-    fiscal_year_list.push(`${year}-${year+1}`);
-}
-const fiscal_year_lut = fiscal_year_list.slice().reverse().reduce(
-    (result, curr, index, array) => {
-        result[curr] = index+1;
-        return result;
-    }, {});
-const min_fiscal_year_count = 1;
-const max_fiscal_year_count = fiscal_year_list.length;
-// -------------------------------------------------
-
 // ----------------- dues amount -------------------
 // Current annual local dues
 
@@ -78,12 +56,6 @@ function sleep(ms) {
 // -------------------------------------------------
 
 export {
-    current_fiscal_year,
-    first_fiscal_year,
-    fiscal_year_list,
-    fiscal_year_lut,
-    min_fiscal_year_count,
-    max_fiscal_year_count,
     dues_amount,
     ACCESS_LEVEL,
     cleanUTF8,

--- a/api/src/models/account.js
+++ b/api/src/models/account.js
@@ -84,7 +84,7 @@ async function getUserApprovalCommittees(user) {
 async function getUserDues(user) {
     return db_conn.promise().execute(
         `SELECT D.duesid, D.name, D.email, D.committee, D.amount, D.status,
-        (SELECT fiscal_year FROM fiscal_year WHERE fyid = D.fiscal_year) fiscal_year
+        D.fiscal_year
         FROM Dues D
         INNER JOIN Users U ON D.email = U.email
         WHERE U.username=?`,

--- a/api/src/models/committee.js
+++ b/api/src/models/committee.js
@@ -15,9 +15,9 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid } from "../utils/fiscal_year.js";
 
-async function getCommitteeCategories(comm, year=max_fiscal_year_count) {
+async function getCommitteeCategories(comm, year=current_fiscal_year_fyid) {
     return db_conn.promise().execute(
         "SELECT category FROM Budget WHERE committee=? AND fiscal_year=? AND status='Approved'",
         [comm, year]

--- a/api/src/models/committee.js
+++ b/api/src/models/committee.js
@@ -15,7 +15,7 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../common_items.js";
+import { max_fiscal_year_count } from "../utils/fiscal_year.js";
 
 async function getCommitteeCategories(comm, year=max_fiscal_year_count) {
     return db_conn.promise().execute(

--- a/api/src/models/dues.js
+++ b/api/src/models/dues.js
@@ -34,7 +34,7 @@ async function getMemberByEmail(email, fiscal_year) {
 
 async function getDuesMembers(year) {
     return db_conn.promise().execute(
-        "SELECT D.duesid, D.name, D.email, D.committee, D.amount, (SELECT fiscal_year FROM fiscal_year WHERE fyid=D.fiscal_year) AS fiscal_year, D.status FROM Dues D WHERE fiscal_year=?",
+        "SELECT D.duesid, D.name, D.email, D.committee, D.amount, D.fiscal_year, D.status FROM Dues D WHERE D.fiscal_year=?",
         [year]
     );
 }
@@ -57,7 +57,7 @@ async function getDuesIncomeActual(year) {
     return db_conn.promise().execute(
         `SELECT I.incomeid, I.source, I.amount, I.refnumber, I.status,
         (SELECT CONCAT(U.first, ' ', U.last) FROM Users U WHERE U.username = I.addedby) addedbyname,
-        (SELECT F.fiscal_year FROM fiscal_year F WHERE F.fyid=I.fiscal_year)
+        I.fiscal_year
         FROM Income I
         WHERE LOWER(I.source) LIKE '%dues%'
         AND I.fiscal_year = ?`,

--- a/api/src/models/dues.js
+++ b/api/src/models/dues.js
@@ -15,13 +15,13 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid } from "../utils/fiscal_year.js";
 
 async function createNewMember(dues) {
     return db_conn.promise().execute(
         `INSERT INTO Dues (timestamp, name, email, id_hash, committee, fiscal_year, amount, status)
         VALUES (NOW(), ?,?,?,?,?,?,'Unpaid')`,
-        [dues.name, dues.email, dues.puid, dues.committees, max_fiscal_year_count, 0]
+        [dues.name, dues.email, dues.puid, dues.committees, current_fiscal_year_fyid, 0]
     );
 }
 

--- a/api/src/models/dues.js
+++ b/api/src/models/dues.js
@@ -15,7 +15,7 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../common_items.js";
+import { max_fiscal_year_count } from "../utils/fiscal_year.js";
 
 async function createNewMember(dues) {
     return db_conn.promise().execute(

--- a/api/src/models/income.js
+++ b/api/src/models/income.js
@@ -15,12 +15,12 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid } from "../utils/fiscal_year.js";
 
 async function createNewDonation(donation) {
     return db_conn.promise().execute(
         "INSERT INTO Income (updated, committee, source, amount, item, type, status, comments, addedby, fiscal_year, refnumber) VALUES (NOW(), ?, ?, ?, ?, ?, ?, ?, ?, ?, '')",
-        [donation.committee, donation.source, donation.amount, donation.item, donation.type, donation.status, donation.comments, donation.user, max_fiscal_year_count]
+        [donation.committee, donation.source, donation.amount, donation.item, donation.type, donation.status, donation.comments, donation.user, current_fiscal_year_fyid]
     );
 }
 

--- a/api/src/models/income.js
+++ b/api/src/models/income.js
@@ -42,7 +42,7 @@ async function getIncome(id) {
     return db_conn.promise().execute(
         `SELECT *, DATE_FORMAT(i.updated, '%Y-%m-%dT%H:%i:%sZ') AS mdate,
         (SELECT CONCAT(U.first, ' ', U.last) FROM Users U WHERE U.username = i.addedby) reportedby,
-        (SELECT fiscal_year FROM fiscal_year WHERE fyid = i.fiscal_year) fiscal_year
+        i.fiscal_year
         FROM Income i WHERE i.incomeid = ?`,
         [id]
     );

--- a/api/src/models/income.js
+++ b/api/src/models/income.js
@@ -15,7 +15,7 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { max_fiscal_year_count } from "../common_items.js";
+import { max_fiscal_year_count } from "../utils/fiscal_year.js";
 
 async function createNewDonation(donation) {
     return db_conn.promise().execute(

--- a/api/src/models/infra.js
+++ b/api/src/models/infra.js
@@ -44,9 +44,25 @@ async function addNewCommittee(comm) {
     );
 }
 
+async function getAllFiscalYears() {
+    return db_conn.promise().execute(
+        "SELECT * FROM fiscal_year",
+        []
+    );
+}
+
+async function createNewFiscalYear(string) {
+    return db_conn.promise().execute(
+        "INSERT INTO fiscal_year (fiscal_year) VALUES (?)",
+        [string]
+    );
+}
+
 export default {
     getAllCommittees,
     getCommitteeByID,
     updateCommitteeDetails,
     addNewCommittee,
+    getAllFiscalYears,
+    createNewFiscalYear,
 };

--- a/api/src/models/purchase.js
+++ b/api/src/models/purchase.js
@@ -24,7 +24,7 @@ async function getFullPurchaseByID(id) {
         p.cost, p.comments, p.fundsource, p.username, p.purchaseid, p.check_type,
         (SELECT CONCAT(U.first, ' ', U.last) FROM Users U WHERE U.username = p.username) purchasedby,
         (SELECT CONCAT(U.first, ' ', U.last) FROM Users U WHERE U.username = p.approvedby) approvedby,
-        (SELECT fiscal_year FROM fiscal_year WHERE fyid = p.fiscal_year) fiscal_year
+        p.fiscal_year
         FROM Purchases p
         WHERE p.purchaseID = ?`,
         [id]

--- a/api/src/models/purchase.js
+++ b/api/src/models/purchase.js
@@ -15,7 +15,8 @@
 */
 
 import { db_conn } from "../utils/db.js";
-import { ACCESS_LEVEL, max_fiscal_year_count } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { max_fiscal_year_count } from "../utils/fiscal_year.js";
 
 async function getFullPurchaseByID(id) {
     return db_conn.promise().execute(

--- a/api/src/models/purchase.js
+++ b/api/src/models/purchase.js
@@ -16,7 +16,7 @@
 
 import { db_conn } from "../utils/db.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid } from "../utils/fiscal_year.js";
 
 async function getFullPurchaseByID(id) {
     return db_conn.promise().execute(
@@ -34,7 +34,7 @@ async function getFullPurchaseByID(id) {
 async function createNewPurchase(purchase) {
     return db_conn.promise().execute(
         "INSERT INTO Purchases (fiscal_year,username,item,purchasereason,vendor,committee,category,cost,status,comments,check_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'Requested', ?, ?)",
-        [max_fiscal_year_count, purchase.user, purchase.item, purchase.reason, purchase.vendor, purchase.committee, purchase.category, purchase.price, purchase.comments, purchase.checkType]
+        [current_fiscal_year_fyid, purchase.user, purchase.item, purchase.reason, purchase.vendor, purchase.committee, purchase.category, purchase.price, purchase.comments, purchase.checkType]
     );
 }
 

--- a/api/src/routes/account.js
+++ b/api/src/routes/account.js
@@ -23,6 +23,7 @@ import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 import bcrypt from "bcrypt";
+import { fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 
 const router = Router();
 const bcrypt_rounds = 10;
@@ -355,6 +356,7 @@ router.get("/:userID/dues", async(req, res, next) => {
 
     try {
         const [results] = await Models.account.getUserDues(req.context.request_user_id);
+        results[0].fiscal_year = fiscal_year_id_to_display[results[0].fiscal_year];
         res.status(200).send(results);
         return next();
     } catch (err) {

--- a/api/src/routes/budgets.js
+++ b/api/src/routes/budgets.js
@@ -18,7 +18,7 @@ import { Router } from "express";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { max_fiscal_year_count, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../utils/committees.js";
@@ -76,7 +76,7 @@ router.post("/:comm", async(req, res, next) => {
 
     // Clear the old budget from the database
     try {
-        await Models.budgets.clearBudget(req.params.comm, max_fiscal_year_count);
+        await Models.budgets.clearBudget(req.params.comm, current_fiscal_year_fyid);
     } catch (err) {
         logger.error(err.stack);
         res.status(500).send("Internal Server Error");
@@ -99,7 +99,7 @@ router.post("/:comm", async(req, res, next) => {
                 category: item.category,
                 amount: item.amount,
                 committee: req.params.comm,
-                year: max_fiscal_year_count,
+                year: current_fiscal_year_fyid,
             };
 
             await Models.budgets.addBudget(budget);
@@ -157,7 +157,7 @@ router.put("/:comm", async(req, res, next) => {
             return next();
         }
 
-        await Models.budgets.approveCommitteeBudget(req.params.comm, max_fiscal_year_count);
+        await Models.budgets.approveCommitteeBudget(req.params.comm, current_fiscal_year_fyid);
 
         res.status(200).send("Approved Budget");
         return next();
@@ -184,7 +184,7 @@ router.get("/submitted", async(req, res, next) => {
         const budgets = {};
 
         for (let committee in committee_id_to_display) {
-            const [results_1] = await Models.budgets.getCommitteeSubmittedBudget(committee, max_fiscal_year_count);
+            const [results_1] = await Models.budgets.getCommitteeSubmittedBudget(committee, current_fiscal_year_fyid);
             budgets[committee] = results_1;
         }
 

--- a/api/src/routes/budgets.js
+++ b/api/src/routes/budgets.js
@@ -18,7 +18,7 @@ import { Router } from "express";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { fiscal_year_list, max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { max_fiscal_year_count, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../utils/committees.js";
@@ -29,7 +29,7 @@ const router = Router();
     Get a list of all fiscal years
 */
 router.get("/years", (req, res, next) => {
-    res.status(200).send(fiscal_year_list);
+    res.status(200).send(fiscal_year_id_to_display);
     return next();
 });
 

--- a/api/src/routes/budgets.js
+++ b/api/src/routes/budgets.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { fiscal_year_list, ACCESS_LEVEL, max_fiscal_year_count, current_fiscal_year } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { fiscal_year_list, max_fiscal_year_count } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display } from "../utils/committees.js";

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -18,7 +18,7 @@ import { Router } from "express";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { current_fiscal_year, fiscal_year_id_to_display, max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year_string, fiscal_year_id_to_display, current_fiscal_year_fyid } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 
@@ -48,7 +48,7 @@ router.get("/:commID/categories/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -143,7 +143,7 @@ router.get("/:commID/budget/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -188,7 +188,7 @@ router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -233,7 +233,7 @@ router.get("/:commID/incometotal/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -278,7 +278,7 @@ router.get("/:commID/purchases/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -319,7 +319,7 @@ router.get("/:commID/income/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -360,7 +360,7 @@ router.get("/:commID/summary/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -410,11 +410,11 @@ router.get("/:commID/csv", async(req, res, next) => {
     }
 
     if (req.query.start === undefined) {
-        req.query.start = `${current_fiscal_year.split("-")[0]}-08-01`;
+        req.query.start = `${current_fiscal_year_string.split("-")[0]}-08-01`;
     }
 
     if (req.query.end === undefined) {
-        req.query.end = `${current_fiscal_year.split("-")[1]}-08-01`;
+        req.query.end = `${current_fiscal_year_string.split("-")[1]}-08-01`;
     }
 
     if ((req.query.start.match(/^\d{4}-\d{2}-\d{2}$/)).length === 0) {

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -18,7 +18,7 @@ import { Router } from "express";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { current_fiscal_year, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
+import { current_fiscal_year, fiscal_year_id_to_display, max_fiscal_year_count } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 
@@ -48,7 +48,7 @@ router.get("/:commID/categories/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -143,7 +143,7 @@ router.get("/:commID/budget/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -188,7 +188,7 @@ router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -233,7 +233,7 @@ router.get("/:commID/incometotal/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -278,7 +278,7 @@ router.get("/:commID/purchases/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -319,7 +319,7 @@ router.get("/:commID/income/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -360,7 +360,7 @@ router.get("/:commID/summary/:year?", async(req, res, next) => {
     }
 
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -18,7 +18,7 @@ import { Router } from "express";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-import { fiscal_year_list, current_fiscal_year, fiscal_year_lut } from "../utils/fiscal_year.js";
+import { current_fiscal_year, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 
@@ -51,13 +51,13 @@ router.get("/:commID/categories/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeCategories(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteeCategories(req.params.commID, req.params.year);
         res.status(200).send(results);
         return next();
     } catch (err) {
@@ -146,7 +146,7 @@ router.get("/:commID/budget/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -164,7 +164,7 @@ router.get("/:commID/budget/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeBudgetTotals(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteeBudgetTotals(req.params.commID, req.params.year);
         if (results.length === 0) {
             res.status(404).send("Invalid committee value");
             return next();
@@ -191,7 +191,7 @@ router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -209,7 +209,7 @@ router.get("/:commID/expensetotal/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeExpenseTotals(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteeExpenseTotals(req.params.commID, req.params.year);
         if (results.length === 0) {
             res.status(404).send("Invalid committee value");
             return next();
@@ -236,7 +236,7 @@ router.get("/:commID/incometotal/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -254,7 +254,7 @@ router.get("/:commID/incometotal/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeIncomeTotals(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteeIncomeTotals(req.params.commID, req.params.year);
         if (results.length === 0) {
             res.status(404).send("Invalid committee value");
             return next();
@@ -281,7 +281,7 @@ router.get("/:commID/purchases/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -299,7 +299,7 @@ router.get("/:commID/purchases/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteePurchases(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteePurchases(req.params.commID, req.params.year);
         res.status(200).send(results);
         return next();
     } catch (err) {
@@ -322,7 +322,7 @@ router.get("/:commID/income/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -340,7 +340,7 @@ router.get("/:commID/income/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeIncome(req.params.commID, fiscal_year_lut[req.params.year]);
+        const [results] = await Models.committee.getCommitteeIncome(req.params.commID, req.params.year);
         res.status(200).send(results);
         return next();
     } catch (err) {
@@ -363,7 +363,7 @@ router.get("/:commID/summary/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -385,7 +385,7 @@ router.get("/:commID/summary/:year?", async(req, res, next) => {
     }
 
     try {
-        const [results] = await Models.committee.getCommitteeBudgetSummary(req.params.commID, fiscal_year_lut[req.params.year], req.query.INSGC === "true");
+        const [results] = await Models.committee.getCommitteeBudgetSummary(req.params.commID, req.params.year, req.query.INSGC === "true");
         res.status(200).send(results);
         return next();
     } catch (err) {

--- a/api/src/routes/committee.js
+++ b/api/src/routes/committee.js
@@ -17,7 +17,8 @@
 import { Router } from "express";
 
 import Models from "../models/index.js";
-import { fiscal_year_list, current_fiscal_year, ACCESS_LEVEL, fiscal_year_lut } from "../common_items.js";
+import { ACCESS_LEVEL } from "../common_items.js";
+import { fiscal_year_list, current_fiscal_year, fiscal_year_lut } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
 

--- a/api/src/routes/dues.js
+++ b/api/src/routes/dues.js
@@ -19,7 +19,7 @@ import crypto from "crypto";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL, dues_amount } from "../common_items.js";
-import { current_fiscal_year, max_fiscal_year_count, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
+import { current_fiscal_year_fyid, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { dues_committees } from "../utils/committees.js";
 
@@ -94,7 +94,7 @@ router.post("/", async(req, res, next) => {
             return next();
         }
 
-        const [results_1] = await Models.dues.getMemberByEmail(req.body.email, max_fiscal_year_count);
+        const [results_1] = await Models.dues.getMemberByEmail(req.body.email, current_fiscal_year_fyid);
         if (results_1.length) {
             // 409 is an unusual status code but sort of applies here?
             res.status(409).send("Member email already exists");
@@ -211,7 +211,7 @@ router.put("/:duesid", async(req, res, next) => {
 */
 router.get("/summary/:year?", async(req, res, next) => {
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -259,7 +259,7 @@ router.get("/summary/:year?", async(req, res, next) => {
 */
 router.get("/all/:year?", async(req, res, next) => {
     if (req.params.year === undefined) {
-        req.params.year = max_fiscal_year_count;
+        req.params.year = current_fiscal_year_fyid;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {

--- a/api/src/routes/dues.js
+++ b/api/src/routes/dues.js
@@ -211,7 +211,7 @@ router.put("/:duesid", async(req, res, next) => {
 */
 router.get("/summary/:year?", async(req, res, next) => {
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {
@@ -259,7 +259,7 @@ router.get("/summary/:year?", async(req, res, next) => {
 */
 router.get("/all/:year?", async(req, res, next) => {
     if (req.params.year === undefined) {
-        req.params.year = current_fiscal_year;
+        req.params.year = max_fiscal_year_count;
     }
 
     if (fiscal_year_id_to_display[req.params.year] === undefined) {

--- a/api/src/routes/dues.js
+++ b/api/src/routes/dues.js
@@ -19,7 +19,7 @@ import crypto from "crypto";
 
 import Models from "../models/index.js";
 import { ACCESS_LEVEL, dues_amount } from "../common_items.js";
-import { current_fiscal_year, fiscal_year_list, fiscal_year_lut, max_fiscal_year_count } from "../utils/fiscal_year.js";
+import { current_fiscal_year, max_fiscal_year_count, fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { dues_committees } from "../utils/committees.js";
 
@@ -214,7 +214,7 @@ router.get("/summary/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -227,7 +227,7 @@ router.get("/summary/:year?", async(req, res, next) => {
             return next();
         }
 
-        const [results_1] = await Models.dues.getDuesMembers(fiscal_year_lut[req.params.year]);
+        const [results_1] = await Models.dues.getDuesMembers(req.params.year);
         const resp_obj = dues_committees.reduce((out, elm) => (out[elm]=[0,0], out), {});
         results_1.forEach(dues => {
             // the shit regex is a holdover since some multi-committee dues use ', ' instead of ','
@@ -262,7 +262,7 @@ router.get("/all/:year?", async(req, res, next) => {
         req.params.year = current_fiscal_year;
     }
 
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -275,7 +275,7 @@ router.get("/all/:year?", async(req, res, next) => {
             return next();
         }
 
-        const [results_1] = await Models.dues.getDuesMembers(fiscal_year_lut[req.params.year]);
+        const [results_1] = await Models.dues.getDuesMembers(req.params.year);
         res.status(200).send(results_1);
         return next();
     } catch (err) {
@@ -289,7 +289,7 @@ router.get("/all/:year?", async(req, res, next) => {
     Get actual dues income for a given year
 */
 router.get("/income/:year", async(req, res, next) => {
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -302,7 +302,7 @@ router.get("/income/:year", async(req, res, next) => {
             return next();
         }
 
-        const [results_1] = await Models.dues.getDuesIncomeActual(fiscal_year_lut[req.params.year]);
+        const [results_1] = await Models.dues.getDuesIncomeActual(req.params.year);
         res.status(200).send(results_1);
         return next();
     } catch (err) {
@@ -316,7 +316,7 @@ router.get("/income/:year", async(req, res, next) => {
     Get expected dues income for a given year
 */
 router.get("/expected/:year", async(req, res, next) => {
-    if (!(fiscal_year_list.includes(req.params.year))) {
+    if (fiscal_year_id_to_display[req.params.year] === undefined) {
         res.status(404).send("Invalid fiscal year");
         return next();
     }
@@ -329,7 +329,7 @@ router.get("/expected/:year", async(req, res, next) => {
             return next();
         }
 
-        const [results_1] = await Models.dues.getDuesIncomeExpected(fiscal_year_lut[req.params.year]);
+        const [results_1] = await Models.dues.getDuesIncomeExpected(req.params.year);
         res.status(200).send({total:results_1.reduce((prev, curr) => { return prev + curr.amount; }, 0),});
         return next();
     } catch (err) {

--- a/api/src/routes/dues.js
+++ b/api/src/routes/dues.js
@@ -18,7 +18,8 @@ import { Router } from "express";
 import crypto from "crypto";
 
 import Models from "../models/index.js";
-import { ACCESS_LEVEL, current_fiscal_year, dues_amount, fiscal_year_list, fiscal_year_lut, max_fiscal_year_count } from "../common_items.js";
+import { ACCESS_LEVEL, dues_amount } from "../common_items.js";
+import { current_fiscal_year, fiscal_year_list, fiscal_year_lut, max_fiscal_year_count } from "../utils/fiscal_year.js";
 import { logger } from "../utils/logging.js";
 import { dues_committees } from "../utils/committees.js";
 

--- a/api/src/routes/income.js
+++ b/api/src/routes/income.js
@@ -20,6 +20,7 @@ import Models from "../models/index.js";
 import { ACCESS_LEVEL } from "../common_items.js";
 import { logger } from "../utils/logging.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
+import { fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 
 const router = Router();
 
@@ -181,6 +182,7 @@ router.get("/:incomeID", async(req, res, next) => {
             return next();
         }
         results[0].committee = committee_id_to_display_readonly_included[results[0].committee];
+        results[0].fiscal_year = fiscal_year_id_to_display[results[0].fiscal_year];
         res.status(200).send(results[0]);
         return next();
     } catch (err) {

--- a/api/src/routes/infra.js
+++ b/api/src/routes/infra.js
@@ -19,8 +19,12 @@ import { Router } from "express";
 import Models from "../models/index.js";
 import { logger } from "../utils/logging.js";
 import comm_loader from "../utils/committees.js";
+<<<<<<< HEAD
 import fiscal_loader from "../utils/fiscal_year.js";
 import { ACCESS_LEVEL } from "../common_items.js";
+=======
+import fiscal_loader, { current_fiscal_year_string } from "../utils/fiscal_year.js";
+>>>>>>> 2000c8d (Resolved lint issues and naming issues)
 
 const router = Router();
 
@@ -189,9 +193,7 @@ router.put("/committees/:commID", async(req, res, next) => {
         return next();
     } catch (err) {
         logger.error(err.stack);
-        if (res.headersSent === false) {
-            res.status(500).send("Internal Server Error");
-        }
+        res.status(500).send("Internal Server Error");
         return next();
     }
 });
@@ -317,6 +319,18 @@ router.post("/fiscal", async(req, res, next) => {
 
     if (isNaN(first_half) || isNaN(second_half)) {
         res.status(400).send("Fiscal Year must consist of two numbers");
+        return next();
+    }
+
+    if (second_half !== (first_half + 1)) {
+        res.status(400).send("Second number must immediately follow the first number");
+        return next();
+    }
+
+    const end_of_current_fy =  parseInt(current_fiscal_year_string.split("-")[1], 10);
+
+    if (first_half < end_of_current_fy) {
+        res.status(400).send("Fiscal year must start after the current fiscal year");
         return next();
     }
 

--- a/api/src/routes/infra.js
+++ b/api/src/routes/infra.js
@@ -19,12 +19,8 @@ import { Router } from "express";
 import Models from "../models/index.js";
 import { logger } from "../utils/logging.js";
 import comm_loader from "../utils/committees.js";
-<<<<<<< HEAD
-import fiscal_loader from "../utils/fiscal_year.js";
+import fiscal_loader, { current_fiscal_year_string }  from "../utils/fiscal_year.js";
 import { ACCESS_LEVEL } from "../common_items.js";
-=======
-import fiscal_loader, { current_fiscal_year_string } from "../utils/fiscal_year.js";
->>>>>>> 2000c8d (Resolved lint issues and naming issues)
 
 const router = Router();
 

--- a/api/src/routes/purchase.js
+++ b/api/src/routes/purchase.js
@@ -24,6 +24,7 @@ import { ACCESS_LEVEL, cleanUTF8 } from "../common_items.js";
 import { logger } from "../utils/logging.js";
 import { mailer } from "../utils/mailer.js";
 import { committee_id_to_display, committee_id_to_display_readonly_included } from "../utils/committees.js";
+import { fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 
 // filter uploaded files based on type
 function fileFilter(req, file, cb) {
@@ -369,6 +370,8 @@ router.get("/:purchaseID", async(req, res, next) => {
                 }
                 results[0].committeeAPI = results[0].committee;
                 results[0].committee = committee_id_to_display_readonly_included[results[0].committee];
+                results[0].fiscalYearAPI = results[0].fiscal_year;
+                results[0].fiscal_year = fiscal_year_id_to_display[results[0].fiscal_year];
                 res.status(200).send(results[0]);
                 return next();
             }
@@ -382,6 +385,8 @@ router.get("/:purchaseID", async(req, res, next) => {
         }
         results[0].committeeAPI = results[0].committee;
         results[0].committee = committee_id_to_display_readonly_included[results[0].committee];
+        results[0].fiscalYearAPI = results[0].fiscal_year;
+        results[0].fiscal_year = fiscal_year_id_to_display[results[0].fiscal_year];
         results[0].costTooHigh = results_2[0].balance < results[0].cost;
         results[0].lowBalance = results_2[0].balance < 200;
         // Approval powers found

--- a/api/src/routes/search.js
+++ b/api/src/routes/search.js
@@ -15,7 +15,7 @@
 */
 
 import { Router } from "express";
-import { fiscal_year_lut } from "../common_items.js";
+import { fiscal_year_lut } from "../utils/fiscal_year.js";
 import { committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 import Models from "../models/index.js";

--- a/api/src/routes/search.js
+++ b/api/src/routes/search.js
@@ -31,12 +31,12 @@ router.post("/", async(req, res, next) => {
         return next();
     }
 
-    if (fiscal_year_lut[req.body.fiscalyear] === undefined && req.body.fiscalyear !== "any") {
+    if (fiscal_year_id_to_display[req.body.fiscalyear] === undefined && req.body.fiscalyear !== "any") {
         res.status(400).send("Improper fiscal year value");
         return next();
     }
 
-    req.body.fiscalyear = fiscal_year_lut[req.body.fiscalyear] !== undefined ? fiscal_year_lut[req.body.fiscalyear] : "any";
+    req.body.fiscalyear = fiscal_year_id_to_display[req.body.fiscalyear] !== undefined ? req.body.fiscalyear : "any";
 
     const [results] = await Models.search.search(req.body, req.context.request_user_id);
     results.forEach((elm) => (elm.committee = committee_id_to_display_readonly_included[elm.committee]));

--- a/api/src/routes/search.js
+++ b/api/src/routes/search.js
@@ -15,7 +15,7 @@
 */
 
 import { Router } from "express";
-import { fiscal_year_lut } from "../utils/fiscal_year.js";
+import { fiscal_year_id_to_display } from "../utils/fiscal_year.js";
 import { committee_id_to_display_readonly_included } from "../utils/committees.js";
 
 import Models from "../models/index.js";

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -31,7 +31,8 @@ import apiLogger from "./middleware/logging.js";
 // Import startup checks
 import db from "./utils/db.js";
 import smtp from "./utils/mailer.js";
-import loader from "./utils/committees.js";
+import comm_loader from "./utils/committees.js";
+import fy_loader from "./utils/fiscal_year.js";
 import oidc from "./utils/oidc.js";
 
 // Import misc utils
@@ -65,13 +66,21 @@ db.init()
     .then((res) => {
         startup_flag -= 1;
         logger.info("MySQL init complete");
-        loader.init()
+        comm_loader.init()
             .then((res) => {
                 startup_flag -= 1;
                 logger.info("Committee Loader init complete");
             })
             .catch((err) => {
                 logger.error("Committee Loader init failed");
+                process.exit(1);
+            });
+        fy_loader.init()
+            .then((res) => {
+                logger.info("Fiscal Year Loader init complete");
+            })
+            .catch((err) => {
+                logger.error("Fiscal Year Loader init failed");
                 process.exit(1);
             });
     })
@@ -135,8 +144,11 @@ function end_all() {
     db.finalize().then(() => {
         logger.warn("MySQL ended");
     });
-    loader.finalize().then(() => {
+    comm_loader.finalize().then(() => {
         logger.warn("Committee Loader ended");
+    });
+    fy_loader.finalize().then(() => {
+        logger.warn("Fiscal Year Loader ended");
     });
     smtp.finalize().then(() => {
         logger.warn("SMTP ended");

--- a/api/src/utils/fiscal_year.js
+++ b/api/src/utils/fiscal_year.js
@@ -16,8 +16,8 @@
 
 import { db_conn } from "./db.js";
 
-let current_fiscal_year;
-let max_fiscal_year_count;
+let current_fiscal_year_string;
+let current_fiscal_year_fyid;
 let fiscal_year_id_to_display;
 
 async function performLoad() {
@@ -27,9 +27,9 @@ async function performLoad() {
             []
         );
 
-        current_fiscal_year = results[results.length - 1].fiscal_year;
+        current_fiscal_year_string = results[results.length - 1].fiscal_year;
 
-        max_fiscal_year_count = results.length;
+        current_fiscal_year_fyid = results.length;
 
         fiscal_year_id_to_display = results.reduce((out, elm) => {
             out[elm.fyid] = elm.fiscal_year;
@@ -56,8 +56,8 @@ async function update() {
 
 // Specific exports
 export {
-    current_fiscal_year,
-    max_fiscal_year_count,
+    current_fiscal_year_string,
+    current_fiscal_year_fyid,
     fiscal_year_id_to_display,
 };
 

--- a/api/src/utils/fiscal_year.js
+++ b/api/src/utils/fiscal_year.js
@@ -14,41 +14,37 @@
    limitations under the License.
 */
 
-import { logger } from "./logging.js";
 import { db_conn } from "./db.js";
 
-let committee_id_to_display;
-let committee_id_to_display_readonly_included;
-let dues_committees;
+let current_fiscal_year;
+let first_fiscal_year;
+let min_fiscal_year_count;
+let max_fiscal_year_count;
+let fiscal_year_list;
+let fiscal_year_lut;
 
 async function performLoad() {
     try {
         const [results] = await db_conn.promise().execute(
-            "SELECT * FROM committees",
+            "SELECT * FROM fiscal_year",
             []
         );
 
-        committee_id_to_display = results.reduce((out, elm) => {
-            if (elm.bank_status === "Active") {
-                out[elm.committee_id] = elm.display_name;
-            }
-            return out;
-        }, {});
+        current_fiscal_year = results[results.length - 1].fiscal_year;
+        first_fiscal_year = results[0].fiscal_year;
 
-        committee_id_to_display_readonly_included = results.reduce((out, elm) => {
-            if (elm.bank_status === "Active" || elm.bank_status === "Read-Only") {
-                out[elm.committee_id] = elm.display_name;
-            }
-            return out;
-        }, {});
+        min_fiscal_year_count = 1;
+        max_fiscal_year_count = results.length;
 
-        dues_committees = results.reduce((out, elm) => {
-            if (elm.dues_status === "Active") {
-                out.push(elm.display_name);
-            }
+        fiscal_year_list = results.reduce((out, elm) => {
+            out.push(elm.fiscal_year);
             return out;
         }, []);
 
+        fiscal_year_lut = results.reduce((out, elm) => {
+            out[elm.fiscal_year] = elm.fyid;
+            return out;
+        }, {});
     } catch (err) {
         throw false;
     }
@@ -70,12 +66,16 @@ async function update() {
 
 // Specific exports
 export {
-    committee_id_to_display,
-    committee_id_to_display_readonly_included,
-    dues_committees,
+    current_fiscal_year,
+    first_fiscal_year,
+    min_fiscal_year_count,
+    max_fiscal_year_count,
+    fiscal_year_list,
+    fiscal_year_lut,
 };
 
 // Standardized exports
+
 export default {
     init,
     finalize,

--- a/api/src/utils/fiscal_year.js
+++ b/api/src/utils/fiscal_year.js
@@ -17,11 +17,8 @@
 import { db_conn } from "./db.js";
 
 let current_fiscal_year;
-let first_fiscal_year;
-let min_fiscal_year_count;
 let max_fiscal_year_count;
-let fiscal_year_list;
-let fiscal_year_lut;
+let fiscal_year_id_to_display;
 
 async function performLoad() {
     try {
@@ -31,18 +28,11 @@ async function performLoad() {
         );
 
         current_fiscal_year = results[results.length - 1].fiscal_year;
-        first_fiscal_year = results[0].fiscal_year;
 
-        min_fiscal_year_count = 1;
         max_fiscal_year_count = results.length;
 
-        fiscal_year_list = results.reduce((out, elm) => {
-            out.push(elm.fiscal_year);
-            return out;
-        }, []);
-
-        fiscal_year_lut = results.reduce((out, elm) => {
-            out[elm.fiscal_year] = elm.fyid;
+        fiscal_year_id_to_display = results.reduce((out, elm) => {
+            out[elm.fyid] = elm.fiscal_year;
             return out;
         }, {});
     } catch (err) {
@@ -67,11 +57,8 @@ async function update() {
 // Specific exports
 export {
     current_fiscal_year,
-    first_fiscal_year,
-    min_fiscal_year_count,
     max_fiscal_year_count,
-    fiscal_year_list,
-    fiscal_year_lut,
+    fiscal_year_id_to_display,
 };
 
 // Standardized exports

--- a/docs/updating_fiscalyear.md
+++ b/docs/updating_fiscalyear.md
@@ -1,35 +1,9 @@
 # Updating the fiscal year
 
-To update Boiler Books for the upcoming fiscal year, you must modify one variable and run a SQL command.
-
-First, update the database. Second, update the code. Upon a push to the 'master' branch, GitHub Actions will automatically deploy the application.
+Updating to add a new fiscal year can be done in the User Interface. Navigate to the Infrastructure tab and "Add Fiscal Year".
+Enter the next year in the text box and press the green button. If any red messages appear, fix the problem reported with the input.
 
 For ease of use, you should also update the [sample data set](/.devcontainer/sample-data.sql) to avoid any errors in development.
-
-## Updating the MySQL database
-
-Add the fiscal year as a entry in the fiscal year lookup table. Update the command to reflect the current year.
-
-The update can be done either visually with PHPMyAdmin _or_ through a shell on the IEEE Server.
-
-### Updating using PHPMyAdmin
-
-* Navigate to the PHPMyAdmin interface and log in
-* Click the `ieee-money` database on the left pane
-* Click the `fiscal_year` table on the center pane
-* Open the MySQL console from the tab on the bottom of the screen
-* Type the command ``INSERT INTO `fiscal_year` (fiscal_year) VALUES ('2022-2023');`` in the MySQL console (change `2022-2023` to the current year)
-* Press Ctrl+Enter to execute the command
-
-### Updating using a shell
-
-* Run the command `docker exec -it boilerbooks-prod_db mysql -u root -p ieee-money` to enter the MySQL console
-* Run the command ``INSERT INTO `fiscal_year` (fiscal_year) VALUES ('2022-2023');`` in the MySQL console (change `2022-2023` to the current year)
-
-## Updating the code
-
-* Modify the `current_fiscal_year` variable in [api/src/common_items.js](https://github.com/PurdueIEEE/boilerbooks/blob/master/api/src/common_items.js#L66)
-* Rebuild and deploy the application as described in [deployment.md](deployment.md#ieee-deploy-information)
 
 ## Updating the sample data
 

--- a/ui/src/components/InfraNav.vue
+++ b/ui/src/components/InfraNav.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="list-group list-group-flush">
     <router-link to="/infra/committees" class="list-group-item" exact-active-class="active">Modify Committees</router-link>
+    <router-link to="/infra/fiscal" class="list-group-item" exact-active-class="active">Modify Fiscal Year</router-link>
     <router-link to="/" class="list-group-item">Boiler Books Home</router-link>
   </div>
 </template>

--- a/ui/src/components/InfraNav.vue
+++ b/ui/src/components/InfraNav.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="list-group list-group-flush">
     <router-link to="/infra/committees" class="list-group-item" exact-active-class="active">Modify Committees</router-link>
-    <router-link to="/infra/fiscal" class="list-group-item" exact-active-class="active">Modify Fiscal Year</router-link>
+    <router-link to="/infra/fiscal" class="list-group-item" exact-active-class="active">Add Fiscal Year</router-link>
     <router-link to="/" class="list-group-item">Boiler Books Home</router-link>
   </div>
 </template>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -309,6 +309,14 @@ const routes = [
         path: 'committees',
         component: () => import('../views/infra/InfraCommittees.vue'),
       },
+      {
+        path: 'fiscal',
+        component: () => import('../views/infra/InfraFiscal.vue'),
+      },
+      {
+        path: ':pathMatch(.*)',
+        component: NotFound
+      }
     ],
     meta: {
       requiresAuth: true,

--- a/ui/src/views/DetailView.vue
+++ b/ui/src/views/DetailView.vue
@@ -251,7 +251,7 @@ export default {
       }
 
       this.dispmsg = '';
-      const response = await fetchWrapperJSON(`/api/v2/committee/${this.purchase.committeeAPI}/categories/${this.purchase.fiscal_year}`, {
+      const response = await fetchWrapperJSON(`/api/v2/committee/${this.purchase.committeeAPI}/categories/${this.purchase.fiscalYearAPI}`, {
         method: 'get',
       });
 

--- a/ui/src/views/dues/DuesIncome.vue
+++ b/ui/src/views/dues/DuesIncome.vue
@@ -10,7 +10,7 @@
           <label for="FiscalSelect" class="form-label fw-bold">Fiscal Year</label>
           <select id="FiscalSelect" class="form-select" v-model="fiscalyear" required>
             <option selected disabled value="">Select...</option>
-            <option v-for="year in fiscalList" v-bind:key="year">{{year}}</option>
+            <option v-for="(val,year) in fiscalList" v-bind:key="year" v-bind:value="year">{{val}}</option>
           </select>
         </div>
       </div>
@@ -84,7 +84,7 @@ export default {
     return {
       actualIncome: [],
       expectedIncome: {total:0},
-      fiscalList: [],
+      fiscalList: {},
       fiscalyear: '',
       error: false,
       dispmsg: "",

--- a/ui/src/views/dues/DuesSummary.vue
+++ b/ui/src/views/dues/DuesSummary.vue
@@ -8,7 +8,7 @@
         <label for="FiscalSelect" class="form-label fw-bold">Fiscal Year</label>
         <select id="FiscalSelect" class="form-select" v-model="fiscalyear" required>
           <option selected disabled value="">Select...</option>
-          <option v-for="year in fiscalList" v-bind:key="year">{{year}}</option>
+          <option v-for="(val,year) in fiscalList" v-bind:key="year" v-bind:value="year">{{val}}</option>
         </select>
       </div>
     </div>
@@ -83,7 +83,7 @@ export default {
     return {
       duesSumm: {},
       rows: [],
-      fiscalList: [],
+      fiscalList: {},
       fiscalyear: '',
       error: false,
       dispmsg: '',

--- a/ui/src/views/financials/FinancialsCommittee.vue
+++ b/ui/src/views/financials/FinancialsCommittee.vue
@@ -15,7 +15,7 @@
         <label for="FiscalSelect" class="form-label fw-bold">Fiscal Year</label>
         <select id="FiscalSelect" class="form-select" v-model="fiscalyear" required>
           <option selected disabled value="">Select...</option>
-          <option v-for="year in fiscalList" v-bind:key="year">{{year}}</option>
+          <option v-for="(val,year) in fiscalList" v-bind:key="year" v-bind:value="year">{{val}}</option>
         </select>
       </div>
     </div>
@@ -145,7 +145,7 @@ export default {
   data() {
     return {
       committeeList: {},
-      fiscalList: [],
+      fiscalList: {},
       committee: '',
       fiscalyear: '',
       found_comm: false,

--- a/ui/src/views/financials/FinancialsSearch.vue
+++ b/ui/src/views/financials/FinancialsSearch.vue
@@ -17,7 +17,7 @@
           <label for="searchFiscalYear" class="form-label fw-bold">Fiscal Year</label>
           <select id="searchFiscalYear" class="form-select" v-model="fiscalyear" required>
             <option selected value="any">ALL FISCAL YEARS</option>
-            <option v-for="val in fiscalList" v-bind:key="val" v-bind:value="val">{{val}}</option>
+            <option v-for="(val,year) in fiscalList" v-bind:key="year" v-bind:value="year">{{val}}</option>
           </select>
         </div>
 
@@ -140,7 +140,7 @@ export default {
   data() {
     return {
       committeeList: {},
-      fiscalList: [],
+      fiscalList: {},
       committee: 'any',
       fiscalyear: 'any',
       joiner: 'OR',

--- a/ui/src/views/infra/InfraCommittees.vue
+++ b/ui/src/views/infra/InfraCommittees.vue
@@ -80,29 +80,29 @@
       </div>
     </div>
     <div class="p-3 m-2 bg-light border rounded-3 row text-start">
-      <div class="col-md-1">
+      <div class="col-md-1 my-3">
         <p class="fs-5 fw-bold">#</p>
       </div>
-      <div class="col-md-3">
+      <div class="col-md-3 mt-3">
         <input id="name-input-new" type="text" v-model="new_committee.display_name" class="form-control" placeholder="Committee Name...">
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2 my-3">
         <input id="api-input-new" type="text" v-model="new_committee.api_name" class="form-control" placeholder="API Key...">
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2 my-3">
         <select id="dues-input-new" v-model="new_committee.bank_status" class="form-select">
           <option>Active</option>
           <option>Inactive</option>
           <option>Read-Only</option>
         </select>
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2 my-3">
         <select id="dues-input-new" v-model="new_committee.dues_status" class="form-select">
           <option>Active</option>
           <option>Inactive</option>
         </select>
       </div>
-      <div class="col-md-2">
+      <div class="col-md-2 my-3">
         <button  v-on:click="addNew" class="btn btn-success"><i class="bi bi-plus-lg"></i></button>
       </div>
     </div>

--- a/ui/src/views/infra/InfraFiscal.vue
+++ b/ui/src/views/infra/InfraFiscal.vue
@@ -1,109 +1,28 @@
 <template>
   <div>
-    <h3>Modify Committees</h3>
+    <h3>View Fiscal Years</h3>
     <div v-if="dispmsg!==''" class="lead fw-bold my-1 fs-3" v-bind:class="{'text-success':!error,'text-danger':error}">{{dispmsg}}</div>
     <br v-else>
 
-    <div class="modal" id="verifyStatusChange" tabindex="-1" aria-labelledby="verifyStatusChange" aria-hidden="true">
-      <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title" id="verifyStatusChange">Are you sure?</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+    <div class="row">
+      <div v-for="(item, idx) in fiscalYearList" v-bind:key="idx" class="col-md-4">
+        <div class="row p-3 m-2 bg-light border rounded-3 text-start">
+          <div class="col-md-2">
+            <p class="fs-5 fw-bold">{{ item.fyid }}</p>
           </div>
-          <div class="modal-body">
-            <p class="fs-5">You have selected to change {{ warning_committee }}'s Finances from "Active" to "Inactive".</p>
-            <p class="fs-5">This is a destructive action: users will no longer be able to complete purchase workflows, income workflows, or view financial history.</p>
-            <p class="fs-5">While this action is reversible, it may have side effects that may corrupt data.</p>
-            <p class="fw-bold fs-4">Are you sure you want to proceed?</p>
-          </div>
-          <div class="modal-footer">
-            <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Go Back</button>
-            <button type="button" class="btn btn-primary" v-on:click="actuallySaveEdit(warning_idx)">Yes, I'm sure!</button>
+          <div class="col-md-8">
+            <p class="fs-5 fw-bold">{{ item.fiscal_year }}</p>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="p-3 m-2 bg-light border rounded-3 row text-start">
-      <div class="col-md-1">
-        <p class="fs-3 fw-bold">ID</p>
+    <div class="row p-3 m-2 bg-light border rounded-3 text-start">
+      <div class="offset-md-2 col-md-4 my-3">
+        <input id="fiscal-input-new" type="text" v-model="new_fiscalyear" class="form-control" placeholder="20XX-20YY">
       </div>
-      <div class="col-md-3">
-        <p class="fs-3 fw-bold">Name</p>
-      </div>
-      <div class="col-md-2">
-        <p class="fs-3 fw-bold">API Key</p>
-      </div>
-      <div class="col-md-2">
-        <p class="fs-3 fw-bold">Finances</p>
-      </div>
-      <div class="col-md-2">
-        <p class="fs-3 fw-bold">Dues</p>
-      </div>
-      <div class="col-md-2">
-        <p class="fs-3 fw-bold">Edit</p>
-      </div>
-    </div>
-    <div v-for="(item, idx) in committeeList" v-bind:key="idx" class="p-3 m-2 bg-light border rounded-3 row text-start">
-      <div class="col-md-1">
-        <p class="fs-5 fw-bold">{{ item.committee_id }}</p>
-      </div>
-      <div class="col-md-3">
-        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.display_name }}</p>
-        <input v-else type="text" v-model="committeeListEdit[idx].display_name" class="form-control" placeholder="Committee Name...">
-      </div>
-      <div class="col-md-2">
-        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.api_name }}</p>
-        <input v-else type="text" v-model="committeeListEdit[idx].api_name" class="form-control" placeholder="Committee Name...">
-      </div>
-      <div class="col-md-2">
-        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.bank_status }}</p>
-        <select v-else v-model="committeeListEdit[idx].bank_status" class="form-select">
-          <option>Active</option>
-          <option>Inactive</option>
-          <option>Read-Only</option>
-        </select>
-      </div>
-      <div class="col-md-2">
-        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.dues_status }}</p>
-        <select v-else v-model="committeeListEdit[idx].dues_status" class="form-select">
-          <option>Active</option>
-          <option>Inactive</option>
-        </select>
-      </div>
-      <div class="col-md-2">
-        <button v-if="!activeEditList[idx]" v-on:click="startEdit(idx)" class="btn btn-secondary"><i class="bi bi-pencil-fill"></i></button>
-        <button v-if="activeEditList[idx]" v-on:click="stopEdit(idx)" class="btn btn-danger"><i class="bi bi-x-lg"></i></button>
-        <span class="mx-2"></span>
-        <button v-if="activeEditList[idx]" v-on:click="saveEdit(idx)" class="btn btn-primary"><i class="bi bi-check-lg"></i></button>
-      </div>
-    </div>
-    <div class="p-3 m-2 bg-light border rounded-3 row text-start">
-      <div class="col-md-1">
-        <p class="fs-5 fw-bold">#</p>
-      </div>
-      <div class="col-md-3">
-        <input id="name-input-new" type="text" v-model="new_committee.display_name" class="form-control" placeholder="Committee Name...">
-      </div>
-      <div class="col-md-2">
-        <input id="api-input-new" type="text" v-model="new_committee.api_name" class="form-control" placeholder="API Key...">
-      </div>
-      <div class="col-md-2">
-        <select id="dues-input-new" v-model="new_committee.bank_status" class="form-select">
-          <option>Active</option>
-          <option>Inactive</option>
-          <option>Read-Only</option>
-        </select>
-      </div>
-      <div class="col-md-2">
-        <select id="dues-input-new" v-model="new_committee.dues_status" class="form-select">
-          <option>Active</option>
-          <option>Inactive</option>
-        </select>
-      </div>
-      <div class="col-md-2">
-        <button  v-on:click="addNew" class="btn btn-success"><i class="bi bi-plus-lg"></i></button>
+      <div class="col-md-4 text-center my-3">
+        <button  v-on:click="addNew" class="btn btn-success"><i class="bi bi-plus-lg"></i> Add Next Fiscal Year</button>
       </div>
     </div>
   </div>
@@ -134,116 +53,41 @@ export default {
     return {
       dispmsg: '',
       error: false,
-      committeeList: [],
-      committeeListEdit: [],
-      activeEditList: [],
-      new_committee: {
-        committee_id: 0,
-        display_name: '',
-        api_name: '',
-        bank_status: 'Active',
-        dues_status: 'Active',
-      },
-      warning_modal: null,
-      warning_committee: '',
-      warning_idx: 0,
+      fiscalYearList: [],
+      new_fiscalyear: ''
     }
+  },
+  mounted() {
+      this.init();
   },
   methods: {
-    startEdit(idx) {
-      this.committeeListEdit[idx] = {... this.committeeList[idx]};
-      this.activeEditList[idx] = true;
-    },
-    stopEdit(idx) {
-      this.activeEditList[idx] = false;
-    },
-    async actuallySaveEdit(idx) {
-      this.warning_modal.hide();
-      const response = await fetchWrapperTXT(`/api/v2/infra/committees/${this.committeeListEdit[idx].committee_id}`, {
-        method: 'put',
-        headers: new Headers({'content-type': 'application/json'}),
-        body: JSON.stringify(this.committeeListEdit[idx]),
+    async init() {
+      const response = await fetchWrapperJSON('/api/v2/infra/fiscal', {
+        method: 'get'
       });
 
-      this.committeeList[idx] = {... this.committeeListEdit[idx]}; // This performs a deep copy
-
-      this.error = response.error;
-      this.dispmsg = response.response;
-
-      if (!this.error) {
-        this.stopEdit(idx);
-      }
-    },
-    saveEdit(idx) {
-      if (this.committeeListEdit[idx].display_name.length > 20) {
+      if (response.error) {
         this.error = true;
-        this.dispmsg = "Display Name must be <= 20 characters";
+        this.dispmsg = response.response;
         return;
       }
 
-      if (this.committeeListEdit[idx].api_name.length > 20) {
-        this.error = true;
-        this.dispmsg = "API Name must be <= 20 characters";
-        return;
-      }
-
-      // Verify that the user is OK with this destructive action
-      if (this.committeeList[idx].bank_status === "Active" && this.committeeListEdit[idx].bank_status === "Inactive") {
-        this.warning_committee = this.committeeListEdit[idx].display_name;
-        this.warning_idx = idx;
-        // Show modal
-        this.warning_modal.show();
-      } else {
-        this.actuallySaveEdit(idx);
-      }
+      this.fiscalYearList = response.response;
     },
     async addNew() {
-      if (this.new_committee.display_name.length > 20) {
-        this.error = true;
-        this.dispmsg = "Display Name must be <= 20 characters";
-        return;
-      }
-
-      if (this.new_committee.api_name.length > 20) {
-        this.error = true;
-        this.dispmsg = "API Name must be <= 20 characters";
-        return;
-      }
-
-      const response = await fetchWrapperTXT(`/api/v2/infra/committees`, {
+      const response = await fetchWrapperTXT(`/api/v2/infra/fiscal`, {
         method: 'post',
         headers: new Headers({'content-type': 'application/json'}),
-        body: JSON.stringify(this.new_committee),
+        body: JSON.stringify({fiscal_year: this.new_fiscalyear}),
       });
 
       this.error = response.error;
       this.dispmsg = response.response;
 
       if (!this.error) {
-        this.committeeList.push({...this.new_committee});
-        this.committeeListEdit.push({...this.new_committee});
-        this.new_committee = {display_name:'',api_name:'',bank_status:'Active',dues_status:'Active'};
+        this.init();
       }
     }
-  },
-  async mounted() {
-    const response = await fetchWrapperJSON('/api/v2/infra/committees', {
-      method: 'get'
-    });
-
-    if (response.error) {
-      this.error = true;
-      this.dispmsg = response.response;
-      return;
-    }
-
-    this.committeeList = response.response;
-    this.committeeListEdit = this.committeeList.map((elm) => ({...elm}));  // This performs a deep copy
-    this.activeEditList = this.committeeList.map(() => (false));
-
-    this.new_committee.committee_id = this.committeeList[this.committeeList.length - 1].committee_id + 1;
-
-    this.warning_modal = new Modal(document.getElementById("verifyStatusChange"),  {backdrop:'static'});
   }
 }
 </script>

--- a/ui/src/views/infra/InfraFiscal.vue
+++ b/ui/src/views/infra/InfraFiscal.vue
@@ -1,0 +1,249 @@
+<template>
+  <div>
+    <h3>Modify Committees</h3>
+    <div v-if="dispmsg!==''" class="lead fw-bold my-1 fs-3" v-bind:class="{'text-success':!error,'text-danger':error}">{{dispmsg}}</div>
+    <br v-else>
+
+    <div class="modal" id="verifyStatusChange" tabindex="-1" aria-labelledby="verifyStatusChange" aria-hidden="true">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="verifyStatusChange">Are you sure?</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p class="fs-5">You have selected to change {{ warning_committee }}'s Finances from "Active" to "Inactive".</p>
+            <p class="fs-5">This is a destructive action: users will no longer be able to complete purchase workflows, income workflows, or view financial history.</p>
+            <p class="fs-5">While this action is reversible, it may have side effects that may corrupt data.</p>
+            <p class="fw-bold fs-4">Are you sure you want to proceed?</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-danger" data-bs-dismiss="modal">Go Back</button>
+            <button type="button" class="btn btn-primary" v-on:click="actuallySaveEdit(warning_idx)">Yes, I'm sure!</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="p-3 m-2 bg-light border rounded-3 row text-start">
+      <div class="col-md-1">
+        <p class="fs-3 fw-bold">ID</p>
+      </div>
+      <div class="col-md-3">
+        <p class="fs-3 fw-bold">Name</p>
+      </div>
+      <div class="col-md-2">
+        <p class="fs-3 fw-bold">API Key</p>
+      </div>
+      <div class="col-md-2">
+        <p class="fs-3 fw-bold">Finances</p>
+      </div>
+      <div class="col-md-2">
+        <p class="fs-3 fw-bold">Dues</p>
+      </div>
+      <div class="col-md-2">
+        <p class="fs-3 fw-bold">Edit</p>
+      </div>
+    </div>
+    <div v-for="(item, idx) in committeeList" v-bind:key="idx" class="p-3 m-2 bg-light border rounded-3 row text-start">
+      <div class="col-md-1">
+        <p class="fs-5 fw-bold">{{ item.committee_id }}</p>
+      </div>
+      <div class="col-md-3">
+        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.display_name }}</p>
+        <input v-else type="text" v-model="committeeListEdit[idx].display_name" class="form-control" placeholder="Committee Name...">
+      </div>
+      <div class="col-md-2">
+        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.api_name }}</p>
+        <input v-else type="text" v-model="committeeListEdit[idx].api_name" class="form-control" placeholder="Committee Name...">
+      </div>
+      <div class="col-md-2">
+        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.bank_status }}</p>
+        <select v-else v-model="committeeListEdit[idx].bank_status" class="form-select">
+          <option>Active</option>
+          <option>Inactive</option>
+          <option>Read-Only</option>
+        </select>
+      </div>
+      <div class="col-md-2">
+        <p v-if="!activeEditList[idx]" class="fs-5 fw-bold">{{ item.dues_status }}</p>
+        <select v-else v-model="committeeListEdit[idx].dues_status" class="form-select">
+          <option>Active</option>
+          <option>Inactive</option>
+        </select>
+      </div>
+      <div class="col-md-2">
+        <button v-if="!activeEditList[idx]" v-on:click="startEdit(idx)" class="btn btn-secondary"><i class="bi bi-pencil-fill"></i></button>
+        <button v-if="activeEditList[idx]" v-on:click="stopEdit(idx)" class="btn btn-danger"><i class="bi bi-x-lg"></i></button>
+        <span class="mx-2"></span>
+        <button v-if="activeEditList[idx]" v-on:click="saveEdit(idx)" class="btn btn-primary"><i class="bi bi-check-lg"></i></button>
+      </div>
+    </div>
+    <div class="p-3 m-2 bg-light border rounded-3 row text-start">
+      <div class="col-md-1">
+        <p class="fs-5 fw-bold">#</p>
+      </div>
+      <div class="col-md-3">
+        <input id="name-input-new" type="text" v-model="new_committee.display_name" class="form-control" placeholder="Committee Name...">
+      </div>
+      <div class="col-md-2">
+        <input id="api-input-new" type="text" v-model="new_committee.api_name" class="form-control" placeholder="API Key...">
+      </div>
+      <div class="col-md-2">
+        <select id="dues-input-new" v-model="new_committee.bank_status" class="form-select">
+          <option>Active</option>
+          <option>Inactive</option>
+          <option>Read-Only</option>
+        </select>
+      </div>
+      <div class="col-md-2">
+        <select id="dues-input-new" v-model="new_committee.dues_status" class="form-select">
+          <option>Active</option>
+          <option>Inactive</option>
+        </select>
+      </div>
+      <div class="col-md-2">
+        <button  v-on:click="addNew" class="btn btn-success"><i class="bi bi-plus-lg"></i></button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+/*
+  Copyright 2022 Purdue IEEE and Hadi Ahmed
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+import { fetchWrapperJSON, fetchWrapperTXT } from '@/api_wrapper';
+
+export default {
+  name: 'InfraFiscal',
+  data() {
+    return {
+      dispmsg: '',
+      error: false,
+      committeeList: [],
+      committeeListEdit: [],
+      activeEditList: [],
+      new_committee: {
+        committee_id: 0,
+        display_name: '',
+        api_name: '',
+        bank_status: 'Active',
+        dues_status: 'Active',
+      },
+      warning_modal: null,
+      warning_committee: '',
+      warning_idx: 0,
+    }
+  },
+  methods: {
+    startEdit(idx) {
+      this.committeeListEdit[idx] = {... this.committeeList[idx]};
+      this.activeEditList[idx] = true;
+    },
+    stopEdit(idx) {
+      this.activeEditList[idx] = false;
+    },
+    async actuallySaveEdit(idx) {
+      this.warning_modal.hide();
+      const response = await fetchWrapperTXT(`/api/v2/infra/committees/${this.committeeListEdit[idx].committee_id}`, {
+        method: 'put',
+        headers: new Headers({'content-type': 'application/json'}),
+        body: JSON.stringify(this.committeeListEdit[idx]),
+      });
+
+      this.committeeList[idx] = {... this.committeeListEdit[idx]}; // This performs a deep copy
+
+      this.error = response.error;
+      this.dispmsg = response.response;
+
+      if (!this.error) {
+        this.stopEdit(idx);
+      }
+    },
+    saveEdit(idx) {
+      if (this.committeeListEdit[idx].display_name.length > 20) {
+        this.error = true;
+        this.dispmsg = "Display Name must be <= 20 characters";
+        return;
+      }
+
+      if (this.committeeListEdit[idx].api_name.length > 20) {
+        this.error = true;
+        this.dispmsg = "API Name must be <= 20 characters";
+        return;
+      }
+
+      // Verify that the user is OK with this destructive action
+      if (this.committeeList[idx].bank_status === "Active" && this.committeeListEdit[idx].bank_status === "Inactive") {
+        this.warning_committee = this.committeeListEdit[idx].display_name;
+        this.warning_idx = idx;
+        // Show modal
+        this.warning_modal.show();
+      } else {
+        this.actuallySaveEdit(idx);
+      }
+    },
+    async addNew() {
+      if (this.new_committee.display_name.length > 20) {
+        this.error = true;
+        this.dispmsg = "Display Name must be <= 20 characters";
+        return;
+      }
+
+      if (this.new_committee.api_name.length > 20) {
+        this.error = true;
+        this.dispmsg = "API Name must be <= 20 characters";
+        return;
+      }
+
+      const response = await fetchWrapperTXT(`/api/v2/infra/committees`, {
+        method: 'post',
+        headers: new Headers({'content-type': 'application/json'}),
+        body: JSON.stringify(this.new_committee),
+      });
+
+      this.error = response.error;
+      this.dispmsg = response.response;
+
+      if (!this.error) {
+        this.committeeList.push({...this.new_committee});
+        this.committeeListEdit.push({...this.new_committee});
+        this.new_committee = {display_name:'',api_name:'',bank_status:'Active',dues_status:'Active'};
+      }
+    }
+  },
+  async mounted() {
+    const response = await fetchWrapperJSON('/api/v2/infra/committees', {
+      method: 'get'
+    });
+
+    if (response.error) {
+      this.error = true;
+      this.dispmsg = response.response;
+      return;
+    }
+
+    this.committeeList = response.response;
+    this.committeeListEdit = this.committeeList.map((elm) => ({...elm}));  // This performs a deep copy
+    this.activeEditList = this.committeeList.map(() => (false));
+
+    this.new_committee.committee_id = this.committeeList[this.committeeList.length - 1].committee_id + 1;
+
+    this.warning_modal = new Modal(document.getElementById("verifyStatusChange"),  {backdrop:'static'});
+  }
+}
+</script>


### PR DESCRIPTION
Utilizing the same infrastructure for UI-based committee updates, allow the treasurer to add new fiscal years from the UI.

The new fiscal year "text" is checked for two 4 digit numbers separated by a hyphen "-", the second number is numerically immediately after the first number, and the new fiscal year is greater than the current fiscal year

Documentation about changing fiscal year has been updated.

- [ ] Should we enforce a sequential fiscal year or allow jumps in time? (i.e., some academic years are not fiscal years) [Nah, this could be a valid use case]